### PR TITLE
Fix compiling on newer node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,6 @@ addons: {apt: {packages: [libopus-dev, libvpx-dev, g++-4.8], sources: [ubuntu-to
 # io.js v3+ requires C++11
 before_install:
   - export CXX="g++-4.8"
-  # https://github.com/node-ffi/node-ffi/issues/451
-  - npm install https://github.com/node-ffi/node-ffi
 
 before_script:
   - export CACHE_DIR="$HOME/cache"

--- a/examples/bin/file-transfer-example.js
+++ b/examples/bin/file-transfer-example.js
@@ -75,10 +75,10 @@ var fixRecvFilename = function(filename) {
  * For more nodes, see: https://wiki.tox.chat/users/nodes
  */
 var nodes = [
-  { maintainer: 'nurupo',
-    address: 'node.tox.biribiri.org',
+  { maintainer: 'Anthony Bilinski',
+    address: 'tox.abilinski.com',
     port: 33445,
-    key: 'F404ABAA1C99A9D37D61AB54898F56793E1DEF8BD46B1038B9D822E8460FAB67' }
+    key: '10C00EB250C3233E343E2AEBA07115A5C28920E9C8D29492F6D00B29049EDC7E' }
 ];
 
 // Bootstrap from nodes

--- a/examples/bin/file-transfer-example.js
+++ b/examples/bin/file-transfer-example.js
@@ -124,7 +124,7 @@ tox.on('fileRecvControl', function(e) {
 
 tox.on('fileChunkRequest', function(e) {
   if(sendFile) {
-    var data = new Buffer(e.length()),
+    var data = Buffer.alloc(e.length()),
         bytesRead = 0;
 
     try {

--- a/examples/bin/packet-simulation.js
+++ b/examples/bin/packet-simulation.js
@@ -17,7 +17,7 @@
  *
  */
 
-var toxcore = require('js-toxcore-c');
+var toxcore = require("js-toxcore-c");
 var tx = new toxcore.Tox(), rx = new toxcore.Tox();
 
 var LOSSLESS_CHANNEL = 160;
@@ -28,10 +28,10 @@ var LOSSY_CHANNEL = 200;
  * For more nodes, see: https://wiki.tox.chat/users/nodes
  */
 var nodes = [
-  { maintainer: 'Anthony Bilinski',
-    address: 'tox.abilinski.com',
+  { maintainer: "Anthony Bilinski",
+    address: "tox.abilinski.com",
     port: 33445,
-    key: '10C00EB250C3233E343E2AEBA07115A5C28920E9C8D29492F6D00B29049EDC7E' }
+    key: "10C00EB250C3233E343E2AEBA07115A5C28920E9C8D29492F6D00B29049EDC7E" }
 ];
 
 
@@ -39,33 +39,33 @@ var nodes = [
 // Setup rx
 //
 
-rx.setNameSync('Packet Bot (recv)');
-rx.setStatusMessageSync('Bot for testing lossless/lossy packet tx/rx');
+rx.setNameSync("Packet Bot (recv)");
+rx.setStatusMessageSync("Bot for testing lossless/lossy packet tx/rx");
 
-rx.on('friendRequest', function(e) {
-  console.log('[rx] Accepting friend request from: %s', e.publicKeyHex().toUpperCase());
+rx.on("friendRequest", function(e) {
+  console.log("[rx] Accepting friend request from: %s", e.publicKeyHex().toUpperCase());
   rx.addFriendNoRequestSync(e.publicKey());
 });
 
-rx.on('friendConnectionStatus', function(e) {
-  console.log('[rx] Friend connection status: %s', e.isConnected() ? 'online' : 'offline');
+rx.on("friendConnectionStatus", function(e) {
+  console.log("[rx] Friend connection status: %s", e.isConnected() ? "online' : 'offline");
 });
 
 var packetCallback = function(e) {
-  var packetType = e.isLossless() ? 'lossless' : 'lossy';
-  console.log('** Received %s packet from [%d] **', packetType, e.friend());
-  console.log('Id: 0x%s', e.id().toString(16));
-  console.log('Data: %s', e.data().toString());
+  var packetType = e.isLossless() ? "lossless' : 'lossy";
+  console.log("** Received %s packet from [%d] **", packetType, e.friend());
+  console.log("Id: 0x%s", e.id().toString(16));
+  console.log("Data: %s", e.data().toString());
 
   // Respond using the same id
   if(e.isLossless()) {
-    rx.sendLosslessPacketSync(e.friend(), e.id(), Buffer.from('lossless-receipt-packet-content'));
+    rx.sendLosslessPacketSync(e.friend(), e.id(), Buffer.from("lossless-receipt-packet-content"));
   } else {
-    rx.sendLossyPacketSync(e.friend(), e.id(), Buffer.from('lossy-receipt-packet-content'));
+    rx.sendLossyPacketSync(e.friend(), e.id(), Buffer.from("lossy-receipt-packet-content"));
   }
 };
 
-// Event 'friendLosslessPacket': Listen for lossless packets
+// Event "friendLosslessPacket": Listen for lossless packets
 // e -> FriendPacketEvent
 //   e.data()       -> {Buffer} Data buffer without leading id byte
 //   e.friend()     -> {Number} Friend number
@@ -73,73 +73,73 @@ var packetCallback = function(e) {
 //   e.id()         -> {Number} Leading Id byte
 //   e.isLossless() -> {Boolean} Whether or not the packet was lossless
 //   e.isLossy()    -> {Boolean} Whether or not the packet was lossy
-rx.on('friendLosslessPacket', packetCallback);
+rx.on("friendLosslessPacket", packetCallback);
 
-// Event: 'friendLossyPacket': Listen for lossy packets
-// e -> FriendPacketEvent (same event as used in 'friendLosslessPacket' event)
-rx.on('friendLossyPacket', packetCallback);
+// Event: "friendLossyPacket": Listen for lossy packets
+// e -> FriendPacketEvent (same event as used in "friendLosslessPacket" event)
+rx.on("friendLossyPacket", packetCallback);
 
 
 //
 // Setup tx
 //
 
-tx.setNameSync('Packet Bot (send)');
-tx.setStatusMessageSync('Bot for testing lossless/lossy packet tx/rx');
+tx.setNameSync("Packet Bot (send)");
+tx.setStatusMessageSync("Bot for testing lossless/lossy packet tx/rx");
 
-tx.on('selfConnectionStatus', function(e) {
+tx.on("selfConnectionStatus", function(e) {
   if(e.isConnected()) {
-    console.log('[tx] Adding friend: %s', rx.getAddressHexSync().toUpperCase());
-    tx.addFriendSync(rx.getAddressSync(), 'Hello');
+    console.log("[tx] Adding friend: %s", rx.getAddressHexSync().toUpperCase());
+    tx.addFriendSync(rx.getAddressSync(), "Hello");
   }
 });
 
-tx.on('friendConnectionStatus', function(e) {
-  console.log('[tx] Friend connection status: %s', e.isConnected() ? 'online' : 'offline');
+tx.on("friendConnectionStatus", function(e) {
+  console.log("[tx] Friend connection status: %s", e.isConnected() ? "online' : 'offline");
   if(e.isConnected()) {
-    console.log('[tx] Sending lossless + lossy packets');
-    tx.sendLosslessPacketSync(e.friend(), LOSSLESS_CHANNEL, Buffer.from('hello-world-lossless'));
-    tx.sendLossyPacketSync(e.friend(), LOSSY_CHANNEL, Buffer.from('hello-world-lossy'));
+    console.log("[tx] Sending lossless + lossy packets");
+    tx.sendLosslessPacketSync(e.friend(), LOSSLESS_CHANNEL, Buffer.from("hello-world-lossless"));
+    tx.sendLossyPacketSync(e.friend(), LOSSY_CHANNEL, Buffer.from("hello-world-lossy"));
 
     var losslessMessage2 = Buffer.concat([
       Buffer.from([LOSSLESS_CHANNEL + 1]),
-      Buffer.from('lossless-2-param')
+      Buffer.from("lossless-2-param")
     ]);
     tx.sendLosslessPacketSync(e.friend(), losslessMessage2);
 
     var lossyMessage2 = Buffer.concat([
       Buffer.from([LOSSY_CHANNEL + 1]),
-      Buffer.from('lossy-2-param')
+      Buffer.from("lossy-2-param")
     ]);
     tx.sendLossyPacketSync(e.friend(), lossyMessage2);
   }
 });
 
-tx.on('friendLosslessPacket', function(e) {
-  console.log('[tx] Received lossless response: %s', e.data().toString());
+tx.on("friendLosslessPacket", function(e) {
+  console.log("[tx] Received lossless response: %s", e.data().toString());
 });
 
-tx.on('friendLossyPacket', function(e) {
-  console.log('[tx] Received lossy response: %s', e.data().toString());
+tx.on("friendLossyPacket", function(e) {
+  console.log("[tx] Received lossy response: %s", e.data().toString());
 });
 
 
 // Bootstrap and start each
-[{ tox: tx, name: 'tx' }, { tox: rx, name: 'rx' }].forEach(function(obj) {
+[{ tox: tx, name: "tx" }, { tox: rx, name: "rx" }].forEach(function(obj) {
   var tox = obj.tox, toxName = obj.name;
 
   // Bootstrap from nodes
   nodes.forEach(function(node) {
     tox.bootstrapSync(node.address, node.port, node.key);
-    console.log('[%s] Successfully bootstrapped from %s at %s:%d', toxName, node.maintainer, node.address, node.port);
-    console.log('... with key %s', node.key);
+    console.log("[%s] Successfully bootstrapped from %s at %s:%d", toxName, node.maintainer, node.address, node.port);
+    console.log("... with key %s", node.key);
   });
 
-  tox.on('selfConnectionStatus', function(e) {
-    console.log('[%s] %s', toxName, e.isConnected() ? 'Connected' : 'Disconnected');
+  tox.on("selfConnectionStatus", function(e) {
+    console.log("[%s] %s", toxName, e.isConnected() ? "Connected' : 'Disconnected");
   });
 
-  console.log('[%s] Address: %s', toxName, tox.getAddressHexSync().toUpperCase());
+  console.log("[%s] Address: %s", toxName, tox.getAddressHexSync().toUpperCase());
 
   tox.start();
 });

--- a/examples/bin/packet-simulation.js
+++ b/examples/bin/packet-simulation.js
@@ -28,10 +28,10 @@ var LOSSY_CHANNEL = 200;
  * For more nodes, see: https://wiki.tox.chat/users/nodes
  */
 var nodes = [
-  { maintainer: 'nurupo',
-    address: 'node.tox.biribiri.org',
+  { maintainer: 'Anthony Bilinski',
+    address: 'tox.abilinski.com',
     port: 33445,
-    key: 'F404ABAA1C99A9D37D61AB54898F56793E1DEF8BD46B1038B9D822E8460FAB67' }
+    key: '10C00EB250C3233E343E2AEBA07115A5C28920E9C8D29492F6D00B29049EDC7E' }
 ];
 
 

--- a/examples/bin/packet-simulation.js
+++ b/examples/bin/packet-simulation.js
@@ -59,9 +59,9 @@ var packetCallback = function(e) {
 
   // Respond using the same id
   if(e.isLossless()) {
-    rx.sendLosslessPacketSync(e.friend(), e.id(), new Buffer('lossless-receipt-packet-content'));
+    rx.sendLosslessPacketSync(e.friend(), e.id(), Buffer.from('lossless-receipt-packet-content'));
   } else {
-    rx.sendLossyPacketSync(e.friend(), e.id(), new Buffer('lossy-receipt-packet-content'));
+    rx.sendLossyPacketSync(e.friend(), e.id(), Buffer.from('lossy-receipt-packet-content'));
   }
 };
 
@@ -98,18 +98,18 @@ tx.on('friendConnectionStatus', function(e) {
   console.log('[tx] Friend connection status: %s', e.isConnected() ? 'online' : 'offline');
   if(e.isConnected()) {
     console.log('[tx] Sending lossless + lossy packets');
-    tx.sendLosslessPacketSync(e.friend(), LOSSLESS_CHANNEL, new Buffer('hello-world-lossless'));
-    tx.sendLossyPacketSync(e.friend(), LOSSY_CHANNEL, new Buffer('hello-world-lossy'));
+    tx.sendLosslessPacketSync(e.friend(), LOSSLESS_CHANNEL, Buffer.from('hello-world-lossless'));
+    tx.sendLossyPacketSync(e.friend(), LOSSY_CHANNEL, Buffer.from('hello-world-lossy'));
 
     var losslessMessage2 = Buffer.concat([
-      new Buffer([LOSSLESS_CHANNEL + 1]),
-      new Buffer('lossless-2-param')
+      Buffer.from([LOSSLESS_CHANNEL + 1]),
+      Buffer.from('lossless-2-param')
     ]);
     tx.sendLosslessPacketSync(e.friend(), losslessMessage2);
 
     var lossyMessage2 = Buffer.concat([
-      new Buffer([LOSSY_CHANNEL + 1]),
-      new Buffer('lossy-2-param')
+      Buffer.from([LOSSY_CHANNEL + 1]),
+      Buffer.from('lossy-2-param')
     ]);
     tx.sendLossyPacketSync(e.friend(), lossyMessage2);
   }

--- a/examples/bin/packet-simulation.js
+++ b/examples/bin/packet-simulation.js
@@ -17,7 +17,6 @@
  *
  */
 
-var buffertools = require('buffertools');
 var toxcore = require('js-toxcore-c');
 var tx = new toxcore.Tox(), rx = new toxcore.Tox();
 
@@ -102,16 +101,16 @@ tx.on('friendConnectionStatus', function(e) {
     tx.sendLosslessPacketSync(e.friend(), LOSSLESS_CHANNEL, new Buffer('hello-world-lossless'));
     tx.sendLossyPacketSync(e.friend(), LOSSY_CHANNEL, new Buffer('hello-world-lossy'));
 
-    var losslessMessage2 = buffertools.concat(
+    var losslessMessage2 = Buffer.concat([
       new Buffer([LOSSLESS_CHANNEL + 1]),
       new Buffer('lossless-2-param')
-    );
+    ]);
     tx.sendLosslessPacketSync(e.friend(), losslessMessage2);
 
-    var lossyMessage2 = buffertools.concat(
+    var lossyMessage2 = Buffer.concat([
       new Buffer([LOSSY_CHANNEL + 1]),
       new Buffer('lossy-2-param')
-    );
+    ]);
     tx.sendLossyPacketSync(e.friend(), lossyMessage2);
   }
 });

--- a/examples/bin/promises-example.js
+++ b/examples/bin/promises-example.js
@@ -37,10 +37,10 @@ var tox = new toxcore.Tox();
 var bootstrap = function(callback) {
   // Define nodes to bootstrap from
   var nodes = [
-    { maintainer: 'nurupo',
-      address: 'node.tox.biribiri.org',
+    { maintainer: 'Anthony Bilinski',
+      address: 'tox.abilinski.com',
       port: 33445,
-      key: 'F404ABAA1C99A9D37D61AB54898F56793E1DEF8BD46B1038B9D822E8460FAB67' }
+      key: '10C00EB250C3233E343E2AEBA07115A5C28920E9C8D29492F6D00B29049EDC7E' }
   ];
 
   async.mapAsync(nodes, function(node, cb) {

--- a/examples/bin/sync-example.js
+++ b/examples/bin/sync-example.js
@@ -130,7 +130,7 @@ tox.on('friendLosslessPacket', function(e){
   var name = tox.getFriendNameSync(e.friend());  
   console.log('**Received lossless packet from ' + '[' + e.friend() + ']');
   console.log(e.data().toString());
-  tox.sendLosslessPacketSync(e.friend(), new Buffer('lossless-receipt-packet-content'));
+  tox.sendLosslessPacketSync(e.friend(), Buffer.from('lossless-receipt-packet-content'));
 });
 
 tox.setNameSync('Sync Bot');

--- a/examples/bin/sync-example.js
+++ b/examples/bin/sync-example.js
@@ -30,11 +30,11 @@ var tox = new toxcore.Tox();
  * Bootstrap tox via hardcoded nodes.
  * For more nodes, see: https://wiki.tox.chat/users/nodes
  */
- var nodes = [
-  { maintainer: 'nurupo',
-    address: 'node.tox.biribiri.org',
+var nodes = [
+  { maintainer: 'Anthony Bilinski',
+    address: 'tox.abilinski.com',
     port: 33445,
-    key: 'F404ABAA1C99A9D37D61AB54898F56793E1DEF8BD46B1038B9D822E8460FAB67' }
+    key: '10C00EB250C3233E343E2AEBA07115A5C28920E9C8D29492F6D00B29049EDC7E' }
 ];
 
 // Bootstrap from nodes

--- a/examples/package.json
+++ b/examples/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "async": "^2.6.0",
-    "buffertools": "^2.1.6",
     "bluebird": "^3.5.1",
     "fs-ext": "^1.0.0",
     "mkdirp": "^0.5.1",

--- a/lib/events.js
+++ b/lib/events.js
@@ -16,11 +16,10 @@
  *
  */
 
-var buffertools = require('buffertools');
 var path = require('path');
 var consts = require(path.join(__dirname, 'consts'));
 
-buffertools.extend();
+require("buffer")
 
 /**
  * Event object fired by {@class Tox}.

--- a/lib/events.js
+++ b/lib/events.js
@@ -19,7 +19,7 @@
 var path = require('path');
 var consts = require(path.join(__dirname, 'consts'));
 
-require("buffer")
+require("buffer");
 
 /**
  * Event object fired by {@class Tox}.

--- a/lib/tox.js
+++ b/lib/tox.js
@@ -18,32 +18,32 @@
 
 /**
  * @file tox.js - Implementation for the new api
- * @todo Have all buffer.toString() specify 'utf8'?
+ * @todo Have all buffer.toString() specify "utf8"?
  * @todo Use max size for all getters?
  * @todo Solve potential TOCTOU/race issues when using async functions that get
  *       the size of some data, allocate a Buffer of that size and call a tox.h
  *       function to set the data to that Buffer.
  */
 
-var events = require('events');
-var fs = require('fs');
-var ref = require('ref-napi');
-var RefArray = require('ref-array-napi');
-var ffi = require('ffi-napi');
-var path = require('path');
-var _ = require('underscore');
-var _util = require('util');
+var events = require("events");
+var fs = require("fs");
+var ref = require("ref-napi");
+var RefArray = require("ref-array-napi");
+var ffi = require("ffi-napi");
+var path = require("path");
+var _ = require("underscore");
+var _util = require("util");
 
-require("buffer")
+require("buffer");
 
-var consts = require(path.join(__dirname, 'consts'));
-var errors = require(path.join(__dirname, 'errors'));
-var toxEvents = require(path.join(__dirname, 'events'));
-var ToxEncryptSave = require(path.join(__dirname, 'toxencryptsave'));
-var ToxOptions = require(path.join(__dirname, 'toxoptions'));
+var consts = require(path.join(__dirname, "consts"));
+var errors = require(path.join(__dirname, "errors"));
+var toxEvents = require(path.join(__dirname, "events"));
+var ToxEncryptSave = require(path.join(__dirname, "toxencryptsave"));
+var ToxOptions = require(path.join(__dirname, "toxoptions"));
 
 // Util functions
-var util = require(path.join(__dirname, 'util'));
+var util = require(path.join(__dirname, "util"));
 var size_t = util.size_t;
 var fromHex = util.fromHex;
 var getDateFromUInt64 = util.getDateFromUInt64;
@@ -53,13 +53,13 @@ var ToxPtr = ref.refType(ref.types.void);
 var ToxOptionsPtr = ref.refType(ToxOptions);
 
 // Common types
-var UInt8Ptr = ref.refType('uint8');
-var Int8Ptr = ref.refType('int8');
-var UInt32Ptr = ref.refType('uint32');
-var UserData = 'pointer';
+var UInt8Ptr = ref.refType("uint8");
+var Int8Ptr = ref.refType("int8");
+var UInt32Ptr = ref.refType("uint32");
+var UserData = "pointer";
 
 // Tox enums and error types
-var CEnum = 'int32';
+var CEnum = "int32";
 var TOX_CONNECTION = CEnum;
 var TOX_FILE_CONTROL = CEnum;
 var TOX_FILE_KIND = CEnum;
@@ -86,39 +86,39 @@ var TOX_ERR_SET_INFO = CEnum;
 var TOX_ERR_SET_TYPING = CEnum;
 
 // Buffer sizes for callbacks
-var KeyBuffer = RefArray('uint8', consts.TOX_KEY_SIZE);
+var KeyBuffer = RefArray("uint8", consts.TOX_KEY_SIZE);
 var KeyBufferPtr = ref.refType(KeyBuffer);
-var RequestMessageBuffer = RefArray('uint8', consts.TOX_MAX_FRIEND_REQUEST_LENGTH);
+var RequestMessageBuffer = RefArray("uint8", consts.TOX_MAX_FRIEND_REQUEST_LENGTH);
 var RequestMessageBufferPtr = ref.refType(RequestMessageBuffer);
-var MessageBuffer = RefArray('uint8', consts.TOX_MAX_MESSAGE_LENGTH);
+var MessageBuffer = RefArray("uint8", consts.TOX_MAX_MESSAGE_LENGTH);
 var MessageBufferPtr = ref.refType(MessageBuffer);
-var NameBuffer = RefArray('uint8', consts.TOX_MAX_NAME_LENGTH);
+var NameBuffer = RefArray("uint8", consts.TOX_MAX_NAME_LENGTH);
 var NameBufferPtr = ref.refType(NameBuffer);
-var StatusMessageBuffer = RefArray('uint8', consts.TOX_MAX_STATUS_MESSAGE_LENGTH);
+var StatusMessageBuffer = RefArray("uint8", consts.TOX_MAX_STATUS_MESSAGE_LENGTH);
 var StatusMessageBufferPtr = ref.refType(StatusMessageBuffer);
-var FilenameBuffer = RefArray('uint8', consts.TOX_MAX_FILENAME_LENGTH);
+var FilenameBuffer = RefArray("uint8", consts.TOX_MAX_FILENAME_LENGTH);
 var FilenameBufferPtr = ref.refType(FilenameBuffer);
 // Use ref.reinterpret() to re-size Buffer at some address
 // https://tootallnate.github.io/ref/#exports-reinterpret
-var UnknownSizeBuffer = RefArray('uint8', 1);
+var UnknownSizeBuffer = RefArray("uint8", 1);
 var UnknownSizeBufferPtr = ref.refType(UnknownSizeBuffer);
 
 // Tox callback types
-var SelfConnectionStatusCallback = ffi.Function('void', [ ToxPtr, TOX_CONNECTION, UserData ]);
-var FriendNameCallback = ffi.Function('void', [ ToxPtr, 'uint32', NameBufferPtr, 'size_t', UserData ]);
-var FriendStatusMessageCallback = ffi.Function('void', [ ToxPtr, 'uint32', StatusMessageBufferPtr, 'size_t', UserData ]);
-var FriendStatusCallback = ffi.Function('void', [ ToxPtr, 'uint32', TOX_USER_STATUS, UserData ]);
-var FriendConnectionStatusCallback = ffi.Function('void', [ ToxPtr, 'uint32', TOX_CONNECTION, UserData ]);
-var FriendTypingCallback = ffi.Function('void', [ ToxPtr, 'uint32', 'bool', UserData ]);
-var FriendReadReceiptCallback = ffi.Function('void', [ ToxPtr, 'uint32', 'uint32', UserData ]);
-var FriendRequestCallback = ffi.Function('void', [ ToxPtr, KeyBufferPtr, RequestMessageBufferPtr, 'size_t', UserData ]);
-var FriendMessageCallback = ffi.Function('void', [ ToxPtr, 'uint32', TOX_MESSAGE_TYPE, MessageBufferPtr, 'size_t', UserData ]);
-var FileRecvControlCallback = ffi.Function('void', [ ToxPtr, 'uint32', 'uint32', TOX_FILE_CONTROL, UserData ]);
-var FileChunkRequestCallback = ffi.Function('void', [ ToxPtr, 'uint32', 'uint32', 'uint64', 'size_t', UserData ]);
-var FileRecvCallback = ffi.Function('void', [ ToxPtr, 'uint32', 'uint32', 'uint32', 'uint64', FilenameBufferPtr, 'size_t', UserData ]);
-var FileRecvChunkCallback = ffi.Function('void', [ ToxPtr, 'uint32', 'uint32', 'uint64', UnknownSizeBufferPtr, 'size_t', UserData ]);
-var FriendLosslessPacketCallback = ffi.Function('void', [ ToxPtr, 'uint32', UInt8Ptr, 'size_t', UserData ]);
-var FriendLossyPacketCallback = ffi.Function('void', [ ToxPtr, 'uint32', UInt8Ptr, 'size_t', UserData ]);
+var SelfConnectionStatusCallback = ffi.Function("void", [ ToxPtr, TOX_CONNECTION, UserData ]);
+var FriendNameCallback = ffi.Function("void", [ ToxPtr, "uint32", NameBufferPtr, "size_t", UserData ]);
+var FriendStatusMessageCallback = ffi.Function("void", [ ToxPtr, "uint32", StatusMessageBufferPtr, "size_t", UserData ]);
+var FriendStatusCallback = ffi.Function("void", [ ToxPtr, "uint32", TOX_USER_STATUS, UserData ]);
+var FriendConnectionStatusCallback = ffi.Function("void", [ ToxPtr, "uint32", TOX_CONNECTION, UserData ]);
+var FriendTypingCallback = ffi.Function("void", [ ToxPtr, "uint32", "bool", UserData ]);
+var FriendReadReceiptCallback = ffi.Function("void", [ ToxPtr, "uint32", "uint32", UserData ]);
+var FriendRequestCallback = ffi.Function("void", [ ToxPtr, KeyBufferPtr, RequestMessageBufferPtr, "size_t", UserData ]);
+var FriendMessageCallback = ffi.Function("void", [ ToxPtr, "uint32", TOX_MESSAGE_TYPE, MessageBufferPtr, "size_t", UserData ]);
+var FileRecvControlCallback = ffi.Function("void", [ ToxPtr, "uint32", "uint32", TOX_FILE_CONTROL, UserData ]);
+var FileChunkRequestCallback = ffi.Function("void", [ ToxPtr, "uint32", "uint32", "uint64", "size_t", UserData ]);
+var FileRecvCallback = ffi.Function("void", [ ToxPtr, "uint32", "uint32", "uint32", "uint64", FilenameBufferPtr, "size_t", UserData ]);
+var FileRecvChunkCallback = ffi.Function("void", [ ToxPtr, "uint32", "uint32", "uint64", UnknownSizeBufferPtr, "size_t", UserData ]);
+var FriendLosslessPacketCallback = ffi.Function("void", [ ToxPtr, "uint32", UInt8Ptr, "size_t", UserData ]);
+var FriendLossyPacketCallback = ffi.Function("void", [ ToxPtr, "uint32", UInt8Ptr, "size_t", UserData ]);
 
 /**
  * Creates a Tox instance.
@@ -127,7 +127,7 @@ var FriendLossyPacketCallback = ffi.Function('void', [ ToxPtr, 'uint32', UInt8Pt
  */
 var Tox = function(opts) {
   if(!opts) opts = {};
-  var libpath = opts['path'];
+  var libpath = opts["path"];
 
   this._emitter = new events.EventEmitter();
   this._library = this.createLibrary(libpath);
@@ -147,16 +147,16 @@ Tox.prototype.inspect = function() {
     obj[k] = this[k];
     // Hacky fix for StringSlice assert error:
     // void node::Buffer::StringSlice(const v8::FunctionCallbackInfo<v8::Value>&) [with node::encoding encoding = (node::encoding)5u]: Assertion `obj_data != __null' failed.
-    if(k === '_options') {
-      obj[k] = '[ToxOptions]';
+    if(k === "_options") {
+      obj[k] = "[ToxOptions]";
     }
   }, this);
   return _util.inspect(obj);
 };
 
 /**
- * Asynchronous-sorta Tox instance creation. Currently is only 'async' if
- * given 'data' as a filepath (string).
+ * Asynchronous-sorta Tox instance creation. Currently is only "async" if
+ * given "data" as a filepath (string).
  * @param {Object} [opts] Options
  * @param {Tox~toxCallback} [callback]
  * @todo Implement with async tox_new?
@@ -168,11 +168,11 @@ Tox.load = function(opts, callback) {
     opts = {};
   }
 
-  var data = opts['data'];
+  var data = opts["data"];
   if(_.isString(data)) {
     fs.readFile(data, function(err, data) {
       if(!err) {
-        opts['data'] = data; // Overwrite data (path) with data (Buffer)
+        opts["data"] = data; // Overwrite data (path) with data (Buffer)
         var tox = new Tox(opts);
         if(callback) {
           callback(undefined, tox);
@@ -192,82 +192,82 @@ Tox.load = function(opts, callback) {
 /**
  * Create a libtoxcore Library instance. If given a path, will use
  * the specified path.
- * @param {String} [libpath='libtoxcore'] - Path to libtoxcore
+ * @param {String} [libpath="libtoxcore"] - Path to libtoxcore
  * @return {ffi.Library}
  */
 Tox.prototype.createLibrary = function(libpath) {
-  libpath = libpath || 'libtoxcore';
+  libpath = libpath || "libtoxcore";
   return ffi.Library(libpath, {
-    'tox_add_tcp_relay':   [ 'bool', [ ToxPtr, Int8Ptr, 'uint16', UInt8Ptr, ref.refType(TOX_ERR_BOOTSTRAP) ] ],
-    'tox_bootstrap':       [ 'bool', [ ToxPtr, Int8Ptr, 'uint16', UInt8Ptr, ref.refType(TOX_ERR_BOOTSTRAP) ] ],
-    'tox_callback_file_chunk_request': [ 'void', [ ToxPtr, FileChunkRequestCallback, UserData ] ],
-    'tox_callback_file_recv':       [ 'void', [ ToxPtr, FileRecvCallback, UserData ] ],
-    'tox_callback_file_recv_chunk': [ 'void', [ ToxPtr, FileRecvChunkCallback, UserData ] ],
-    'tox_callback_file_recv_control': [ 'void', [ ToxPtr, FileRecvControlCallback, UserData ] ],
-    'tox_callback_friend_connection_status': [ 'void', [ ToxPtr, FriendConnectionStatusCallback, UserData ] ],
-    'tox_callback_friend_message': [ 'void', [ ToxPtr, FriendMessageCallback, UserData ] ],
-    'tox_callback_friend_name': [ 'void', [ ToxPtr, FriendNameCallback, UserData ] ],
-    'tox_callback_friend_read_receipt': [ 'void', [ ToxPtr, FriendReadReceiptCallback, UserData ] ],
-    'tox_callback_friend_request': [ 'void', [ ToxPtr, FriendRequestCallback, UserData ] ],
-    'tox_callback_friend_status': [ 'void', [ ToxPtr, FriendStatusCallback, UserData ] ],
-    'tox_callback_friend_status_message': [ 'void', [ ToxPtr, FriendStatusMessageCallback, UserData ] ],
-    'tox_callback_friend_typing': [ 'void', [ ToxPtr, FriendTypingCallback, UserData ] ],
-    'tox_callback_self_connection_status': [ 'void', [ ToxPtr, SelfConnectionStatusCallback, UserData ] ],
-    'tox_callback_friend_lossless_packet': [ 'void', [ ToxPtr, FriendLosslessPacketCallback, UserData ] ],
-    'tox_callback_friend_lossy_packet':    [ 'void', [ ToxPtr, FriendLossyPacketCallback, UserData ] ],
-    'tox_file_control':    [ 'bool',   [ ToxPtr, 'uint32', 'uint32', TOX_FILE_CONTROL, ref.refType(TOX_ERR_FILE_CONTROL) ] ],
-    'tox_file_get_file_id':[ 'bool',   [ ToxPtr, 'uint32', 'uint32', UInt8Ptr, ref.refType(TOX_ERR_FILE_GET) ] ],
-    'tox_file_seek':       [ 'bool',   [ ToxPtr, 'uint32', 'uint32', 'uint64', ref.refType(TOX_ERR_FILE_SEEK) ] ],
-    'tox_file_send':       [ 'uint32', [ ToxPtr, 'uint32', 'uint32', 'uint64', UInt8Ptr, UInt8Ptr, 'size_t', ref.refType(TOX_ERR_FILE_SEND) ] ],
-    'tox_file_send_chunk': [ 'bool',   [ ToxPtr, 'uint32', 'uint32', 'uint64', UInt8Ptr, 'size_t', ref.refType(TOX_ERR_FILE_SEND_CHUNK) ] ],
-    'tox_friend_add':      [ 'uint32', [ ToxPtr, UInt8Ptr, UInt8Ptr, 'size_t', ref.refType(TOX_ERR_FRIEND_ADD) ] ],
-    'tox_friend_add_norequest': [ 'uint32', [ ToxPtr, UInt8Ptr, ref.refType(TOX_ERR_FRIEND_ADD) ] ],
-    'tox_friend_by_public_key': [ 'uint32', [ ToxPtr, UInt8Ptr, ref.refType(TOX_ERR_FRIEND_BY_PUBLIC_KEY) ] ],
-    'tox_friend_delete':   [ 'bool', [ ToxPtr, 'uint32', ref.refType(TOX_ERR_FRIEND_DELETE) ] ],
-    'tox_friend_exists':   [ 'bool', [ ToxPtr, 'uint32' ] ],
-    'tox_friend_get_connection_status':     [ TOX_CONNECTION, [ ToxPtr, 'uint32', ref.refType(TOX_ERR_FRIEND_QUERY) ] ],
-    'tox_friend_get_last_online': [ 'uint64', [ ToxPtr, 'uint32', ref.refType(TOX_ERR_FRIEND_GET_LAST_ONLINE) ] ],
-    'tox_friend_get_name':      [ 'bool',   [ ToxPtr, 'uint32', UInt8Ptr, ref.refType(TOX_ERR_FRIEND_QUERY) ] ],
-    'tox_friend_get_name_size': [ 'size_t', [ ToxPtr, 'uint32', ref.refType(TOX_ERR_FRIEND_QUERY) ] ],
-    'tox_friend_get_public_key': [ 'uint32', [ ToxPtr, 'uint32', UInt8Ptr, ref.refType(TOX_ERR_FRIEND_GET_PUBLIC_KEY) ] ],
-    'tox_friend_get_status':    [ TOX_USER_STATUS, [ ToxPtr, 'uint32', ref.refType(TOX_ERR_FRIEND_QUERY) ] ],
-    'tox_friend_get_status_message':      [ 'bool',   [ ToxPtr, 'uint32', UInt8Ptr, ref.refType(TOX_ERR_FRIEND_QUERY) ] ],
-    'tox_friend_get_status_message_size': [ 'size_t', [ ToxPtr, 'uint32', ref.refType(TOX_ERR_FRIEND_QUERY) ] ],
-    'tox_friend_send_lossless_packet': [ 'bool', [ ToxPtr, 'uint32', UInt8Ptr, 'size_t', ref.refType(TOX_ERR_FRIEND_CUSTOM_PACKET) ] ],
-    'tox_friend_send_lossy_packet':    [ 'bool', [ ToxPtr, 'uint32', UInt8Ptr, 'size_t', ref.refType(TOX_ERR_FRIEND_CUSTOM_PACKET) ] ],
-    'tox_friend_send_message': [ 'uint32', [ ToxPtr, 'uint32', TOX_MESSAGE_TYPE, UInt8Ptr, 'size_t', ref.refType(TOX_ERR_FRIEND_SEND_MESSAGE) ] ],
-    'tox_hash': [ 'bool', [ UInt8Ptr, UInt8Ptr, 'size_t' ] ],
-    'tox_iteration_interval': [ 'uint32', [ ToxPtr ] ],
-    'tox_iterate':         [ 'void' , [ ToxPtr ] ],
-    'tox_kill': [ 'void',  [ ToxPtr ] ],
-    'tox_new':  [ ToxPtr, [ ToxOptionsPtr, ref.refType(TOX_ERR_NEW) ] ],
-    'tox_get_savedata':    [ 'void',  [ ToxPtr, UInt8Ptr ] ],
-    'tox_get_savedata_size':  [ 'size_t',  [ ToxPtr ] ],
-    'tox_options_default': [ 'void', [ ToxOptionsPtr ] ],
-    'tox_options_free':    [ 'void', [ ToxOptionsPtr ] ],
-    'tox_options_new':     [ ToxOptionsPtr, [ ref.refType(TOX_ERR_OPTIONS_NEW) ] ],
-    'tox_self_get_address':  [ 'void',   [ ToxPtr, UInt8Ptr ] ],
-    'tox_self_get_connection_status': [ TOX_CONNECTION, [ ToxPtr ] ],
-    'tox_self_get_friend_list':      [ 'void',   [ ToxPtr, UInt32Ptr ] ],
-    'tox_self_get_friend_list_size': [ 'size_t', [ ToxPtr ] ],
-    'tox_self_get_name':     [ 'void',   [ ToxPtr, UInt8Ptr ] ],
-    'tox_self_get_name_size':[ 'size_t', [ ToxPtr ] ],
-    'tox_self_get_nospam':   [ 'uint32', [ ToxPtr ] ],
-    'tox_self_get_public_key': [ 'void', [ ToxPtr, UInt8Ptr ] ],
-    'tox_self_get_secret_key': [ 'void', [ ToxPtr, UInt8Ptr ] ],
-    'tox_self_get_status':   [ TOX_USER_STATUS, [ ToxPtr ] ],
-    'tox_self_get_status_message':     [ 'void',   [ ToxPtr, UInt8Ptr ] ],
-    'tox_self_get_status_message_size':[ 'size_t', [ ToxPtr ] ],
-    'tox_self_get_tcp_port': [ 'uint16', [ ToxPtr, ref.refType(TOX_ERR_GET_PORT) ] ],
-    'tox_self_get_udp_port': [ 'uint16', [ ToxPtr, ref.refType(TOX_ERR_GET_PORT) ] ],
-    'tox_self_set_name':   [ 'bool', [ ToxPtr, UInt8Ptr, 'size_t', ref.refType(TOX_ERR_SET_INFO) ] ],
-    'tox_self_set_nospam':   [ 'void',   [ ToxPtr, 'uint32' ] ],
-    'tox_self_set_status': [ 'void', [ ToxPtr, TOX_USER_STATUS ] ],
-    'tox_self_set_status_message': [ 'bool', [ ToxPtr, UInt8Ptr, 'size_t', ref.refType(TOX_ERR_SET_INFO) ] ],
-    'tox_self_set_typing':   [ 'bool',   [ ToxPtr, 'uint32', 'bool', ref.refType(TOX_ERR_SET_TYPING) ] ],
-    'tox_version_major': [ 'uint32', [ ] ],
-    'tox_version_minor': [ 'uint32', [ ] ],
-    'tox_version_patch': [ 'uint32', [ ] ]
+    "tox_add_tcp_relay":   [ "bool", [ ToxPtr, Int8Ptr, "uint16", UInt8Ptr, ref.refType(TOX_ERR_BOOTSTRAP) ] ],
+    "tox_bootstrap":       [ "bool", [ ToxPtr, Int8Ptr, "uint16", UInt8Ptr, ref.refType(TOX_ERR_BOOTSTRAP) ] ],
+    "tox_callback_file_chunk_request": [ "void", [ ToxPtr, FileChunkRequestCallback, UserData ] ],
+    "tox_callback_file_recv":       [ "void", [ ToxPtr, FileRecvCallback, UserData ] ],
+    "tox_callback_file_recv_chunk": [ "void", [ ToxPtr, FileRecvChunkCallback, UserData ] ],
+    "tox_callback_file_recv_control": [ "void", [ ToxPtr, FileRecvControlCallback, UserData ] ],
+    "tox_callback_friend_connection_status": [ "void", [ ToxPtr, FriendConnectionStatusCallback, UserData ] ],
+    "tox_callback_friend_message": [ "void", [ ToxPtr, FriendMessageCallback, UserData ] ],
+    "tox_callback_friend_name": [ "void", [ ToxPtr, FriendNameCallback, UserData ] ],
+    "tox_callback_friend_read_receipt": [ "void", [ ToxPtr, FriendReadReceiptCallback, UserData ] ],
+    "tox_callback_friend_request": [ "void", [ ToxPtr, FriendRequestCallback, UserData ] ],
+    "tox_callback_friend_status": [ "void", [ ToxPtr, FriendStatusCallback, UserData ] ],
+    "tox_callback_friend_status_message": [ "void", [ ToxPtr, FriendStatusMessageCallback, UserData ] ],
+    "tox_callback_friend_typing": [ "void", [ ToxPtr, FriendTypingCallback, UserData ] ],
+    "tox_callback_self_connection_status": [ "void", [ ToxPtr, SelfConnectionStatusCallback, UserData ] ],
+    "tox_callback_friend_lossless_packet": [ "void", [ ToxPtr, FriendLosslessPacketCallback, UserData ] ],
+    "tox_callback_friend_lossy_packet":    [ "void", [ ToxPtr, FriendLossyPacketCallback, UserData ] ],
+    "tox_file_control":    [ "bool",   [ ToxPtr, "uint32", "uint32", TOX_FILE_CONTROL, ref.refType(TOX_ERR_FILE_CONTROL) ] ],
+    "tox_file_get_file_id":[ "bool",   [ ToxPtr, "uint32", "uint32", UInt8Ptr, ref.refType(TOX_ERR_FILE_GET) ] ],
+    "tox_file_seek":       [ "bool",   [ ToxPtr, "uint32", "uint32", "uint64", ref.refType(TOX_ERR_FILE_SEEK) ] ],
+    "tox_file_send":       [ "uint32", [ ToxPtr, "uint32", "uint32", "uint64", UInt8Ptr, UInt8Ptr, "size_t", ref.refType(TOX_ERR_FILE_SEND) ] ],
+    "tox_file_send_chunk": [ "bool",   [ ToxPtr, "uint32", "uint32", "uint64", UInt8Ptr, "size_t", ref.refType(TOX_ERR_FILE_SEND_CHUNK) ] ],
+    "tox_friend_add":      [ "uint32", [ ToxPtr, UInt8Ptr, UInt8Ptr, "size_t", ref.refType(TOX_ERR_FRIEND_ADD) ] ],
+    "tox_friend_add_norequest": [ "uint32", [ ToxPtr, UInt8Ptr, ref.refType(TOX_ERR_FRIEND_ADD) ] ],
+    "tox_friend_by_public_key": [ "uint32", [ ToxPtr, UInt8Ptr, ref.refType(TOX_ERR_FRIEND_BY_PUBLIC_KEY) ] ],
+    "tox_friend_delete":   [ "bool", [ ToxPtr, "uint32", ref.refType(TOX_ERR_FRIEND_DELETE) ] ],
+    "tox_friend_exists":   [ "bool", [ ToxPtr, "uint32" ] ],
+    "tox_friend_get_connection_status":     [ TOX_CONNECTION, [ ToxPtr, "uint32", ref.refType(TOX_ERR_FRIEND_QUERY) ] ],
+    "tox_friend_get_last_online": [ "uint64", [ ToxPtr, "uint32", ref.refType(TOX_ERR_FRIEND_GET_LAST_ONLINE) ] ],
+    "tox_friend_get_name":      [ "bool",   [ ToxPtr, "uint32", UInt8Ptr, ref.refType(TOX_ERR_FRIEND_QUERY) ] ],
+    "tox_friend_get_name_size": [ "size_t", [ ToxPtr, "uint32", ref.refType(TOX_ERR_FRIEND_QUERY) ] ],
+    "tox_friend_get_public_key": [ "uint32", [ ToxPtr, "uint32", UInt8Ptr, ref.refType(TOX_ERR_FRIEND_GET_PUBLIC_KEY) ] ],
+    "tox_friend_get_status":    [ TOX_USER_STATUS, [ ToxPtr, "uint32", ref.refType(TOX_ERR_FRIEND_QUERY) ] ],
+    "tox_friend_get_status_message":      [ "bool",   [ ToxPtr, "uint32", UInt8Ptr, ref.refType(TOX_ERR_FRIEND_QUERY) ] ],
+    "tox_friend_get_status_message_size": [ "size_t", [ ToxPtr, "uint32", ref.refType(TOX_ERR_FRIEND_QUERY) ] ],
+    "tox_friend_send_lossless_packet": [ "bool", [ ToxPtr, "uint32", UInt8Ptr, "size_t", ref.refType(TOX_ERR_FRIEND_CUSTOM_PACKET) ] ],
+    "tox_friend_send_lossy_packet":    [ "bool", [ ToxPtr, "uint32", UInt8Ptr, "size_t", ref.refType(TOX_ERR_FRIEND_CUSTOM_PACKET) ] ],
+    "tox_friend_send_message": [ "uint32", [ ToxPtr, "uint32", TOX_MESSAGE_TYPE, UInt8Ptr, "size_t", ref.refType(TOX_ERR_FRIEND_SEND_MESSAGE) ] ],
+    "tox_hash": [ "bool", [ UInt8Ptr, UInt8Ptr, "size_t" ] ],
+    "tox_iteration_interval": [ "uint32", [ ToxPtr ] ],
+    "tox_iterate":         [ "void" , [ ToxPtr ] ],
+    "tox_kill": [ "void",  [ ToxPtr ] ],
+    "tox_new":  [ ToxPtr, [ ToxOptionsPtr, ref.refType(TOX_ERR_NEW) ] ],
+    "tox_get_savedata":    [ "void",  [ ToxPtr, UInt8Ptr ] ],
+    "tox_get_savedata_size":  [ "size_t",  [ ToxPtr ] ],
+    "tox_options_default": [ "void", [ ToxOptionsPtr ] ],
+    "tox_options_free":    [ "void", [ ToxOptionsPtr ] ],
+    "tox_options_new":     [ ToxOptionsPtr, [ ref.refType(TOX_ERR_OPTIONS_NEW) ] ],
+    "tox_self_get_address":  [ "void",   [ ToxPtr, UInt8Ptr ] ],
+    "tox_self_get_connection_status": [ TOX_CONNECTION, [ ToxPtr ] ],
+    "tox_self_get_friend_list":      [ "void",   [ ToxPtr, UInt32Ptr ] ],
+    "tox_self_get_friend_list_size": [ "size_t", [ ToxPtr ] ],
+    "tox_self_get_name":     [ "void",   [ ToxPtr, UInt8Ptr ] ],
+    "tox_self_get_name_size":[ "size_t", [ ToxPtr ] ],
+    "tox_self_get_nospam":   [ "uint32", [ ToxPtr ] ],
+    "tox_self_get_public_key": [ "void", [ ToxPtr, UInt8Ptr ] ],
+    "tox_self_get_secret_key": [ "void", [ ToxPtr, UInt8Ptr ] ],
+    "tox_self_get_status":   [ TOX_USER_STATUS, [ ToxPtr ] ],
+    "tox_self_get_status_message":     [ "void",   [ ToxPtr, UInt8Ptr ] ],
+    "tox_self_get_status_message_size":[ "size_t", [ ToxPtr ] ],
+    "tox_self_get_tcp_port": [ "uint16", [ ToxPtr, ref.refType(TOX_ERR_GET_PORT) ] ],
+    "tox_self_get_udp_port": [ "uint16", [ ToxPtr, ref.refType(TOX_ERR_GET_PORT) ] ],
+    "tox_self_set_name":   [ "bool", [ ToxPtr, UInt8Ptr, "size_t", ref.refType(TOX_ERR_SET_INFO) ] ],
+    "tox_self_set_nospam":   [ "void",   [ ToxPtr, "uint32" ] ],
+    "tox_self_set_status": [ "void", [ ToxPtr, TOX_USER_STATUS ] ],
+    "tox_self_set_status_message": [ "bool", [ ToxPtr, UInt8Ptr, "size_t", ref.refType(TOX_ERR_SET_INFO) ] ],
+    "tox_self_set_typing":   [ "bool",   [ ToxPtr, "uint32", "bool", ref.refType(TOX_ERR_SET_TYPING) ] ],
+    "tox_version_major": [ "uint32", [ ] ],
+    "tox_version_minor": [ "uint32", [ ] ],
+    "tox_version_patch": [ "uint32", [ ] ]
   });
 };
 
@@ -495,7 +495,7 @@ Tox.prototype.iterateSync = function() {
 Tox.prototype.getAddress = function(callback) {
   this._performGetter({
     api: this.getLibrary().tox_self_get_address.async.bind(undefined, this.getHandle()),
-    format: 'raw',
+    format: "raw",
     size: consts.TOX_FRIEND_ADDRESS_SIZE,
     async: true, callback: callback
   });
@@ -508,7 +508,7 @@ Tox.prototype.getAddress = function(callback) {
 Tox.prototype.getAddressSync = function() {
   return this._performGetter({
     api: this.getLibrary().tox_self_get_address.bind(undefined, this.getHandle()),
-    format: 'raw',
+    format: "raw",
     size: consts.TOX_FRIEND_ADDRESS_SIZE
   });
 };
@@ -587,7 +587,7 @@ Tox.prototype.getNospamSync = function() {
 Tox.prototype.getPublicKey = function(callback) {
   this._performGetter({
     api: this.getLibrary().tox_self_get_public_key.async.bind(undefined, this.getHandle()),
-    format: 'raw',
+    format: "raw",
     size: consts.TOX_PUBLIC_KEY_SIZE,
     async: true, callback: callback
   });
@@ -600,7 +600,7 @@ Tox.prototype.getPublicKey = function(callback) {
 Tox.prototype.getPublicKeySync = function() {
   return this._performGetter({
     api: this.getLibrary().tox_self_get_public_key.bind(undefined, this.getHandle()),
-    format: 'raw',
+    format: "raw",
     size: consts.TOX_PUBLIC_KEY_SIZE
   });
 };
@@ -612,7 +612,7 @@ Tox.prototype.getPublicKeySync = function() {
 Tox.prototype.getSecretKey = function(callback) {
   this._performGetter({
     api: this.getLibrary().tox_self_get_secret_key.async.bind(undefined, this.getHandle()),
-    format: 'raw',
+    format: "raw",
     size: consts.TOX_PUBLIC_KEY_SIZE,
     async: true, callback: callback
   });
@@ -625,7 +625,7 @@ Tox.prototype.getSecretKey = function(callback) {
 Tox.prototype.getSecretKeySync = function() {
   return this._performGetter({
     api: this.getLibrary().tox_self_get_secret_key.bind(undefined, this.getHandle()),
-    format: 'raw',
+    format: "raw",
     size: consts.TOX_SECRET_KEY_SIZE
   });
 };
@@ -684,7 +684,7 @@ Tox.prototype.getNameSizeSync = function() {
 Tox.prototype.getName = function(callback) {
   this._performGetter({
     api: this.getLibrary().tox_self_get_name.async.bind(undefined, this.getHandle()),
-    format: 'string',
+    format: "string",
     size: Tox.prototype.getNameSize.bind(this),
     async: true, callback: callback
   });
@@ -697,7 +697,7 @@ Tox.prototype.getName = function(callback) {
 Tox.prototype.getNameSync = function() {
   return this._performGetter({
     api: this.getLibrary().tox_self_get_name.bind(undefined, this.getHandle()),
-    format: 'string',
+    format: "string",
     size: Tox.prototype.getNameSizeSync.bind(this)
   });
 };
@@ -756,7 +756,7 @@ Tox.prototype.getStatusMessageSizeSync = function() {
 Tox.prototype.getStatusMessage = function(callback) {
   this._performGetter({
     api: this.getLibrary().tox_self_get_status_message.async.bind(undefined, this.getHandle()),
-    format: 'string',
+    format: "string",
     size: Tox.prototype.getStatusMessageSize.bind(this),
     async: true, callback: callback
   });
@@ -769,7 +769,7 @@ Tox.prototype.getStatusMessage = function(callback) {
 Tox.prototype.getStatusMessageSync = function() {
   return this._performGetter({
     api: this.getLibrary().tox_self_get_status_message.bind(undefined, this.getHandle()),
-    format: 'string',
+    format: "string",
     size: Tox.prototype.getStatusMessageSizeSync.bind(this)
   });
 };
@@ -1094,7 +1094,7 @@ Tox.prototype.getFriendList = function(callback) {
   var _this = this;
   this.getFriendListSize(function(err, size) {
     if(!err) {
-      var arr = (new RefArray('uint32'))(size);
+      var arr = (new RefArray("uint32"))(size);
       _this.getLibrary().tox_self_get_friend_list.async(
         _this.getHandle(), arr.buffer, function(err) {
 
@@ -1124,7 +1124,7 @@ Tox.prototype.getFriendList = function(callback) {
 Tox.prototype.getFriendListSync = function() {
   this._checkHandleSync();
   var size = this.getFriendListSizeSync(),
-      arr = (new RefArray('uint32'))(size);
+      arr = (new RefArray("uint32"))(size);
   this.getLibrary().tox_self_get_friend_list(this.getHandle(), arr.buffer);
 
   // RefArray -> Javascript Array
@@ -1168,7 +1168,7 @@ Tox.prototype.getFriendNameSizeSync = function(friend) {
 Tox.prototype.getFriendName = function(friend, callback) {
   this._performFriendGetter({
     api: this.getLibrary().tox_friend_get_name.async.bind(undefined, this.getHandle()),
-    format: 'string',
+    format: "string",
     friend: friend,
     size: consts.TOX_MAX_NAME_LENGTH,
     async: true, callback: callback
@@ -1184,7 +1184,7 @@ Tox.prototype.getFriendName = function(friend, callback) {
 Tox.prototype.getFriendNameSync = function(friend) {
   return this._performFriendGetter({
     api: this.getLibrary().tox_friend_get_name.bind(undefined, this.getHandle()),
-    format: 'string',
+    format: "string",
     friend: friend,
     size: consts.TOX_MAX_NAME_LENGTH
   });
@@ -1223,7 +1223,7 @@ Tox.prototype.getFriendStatusMessageSizeSync = function(friend) {
 Tox.prototype.getFriendStatusMessage = function(friend, callback) {
   this._performFriendGetter({
     api: this.getLibrary().tox_friend_get_status_message.async.bind(undefined, this.getHandle()),
-    format: 'string',
+    format: "string",
     friend: friend,
     size: consts.TOX_MAX_STATUS_MESSAGE_LENGTH,
     async: true, callback: callback
@@ -1239,7 +1239,7 @@ Tox.prototype.getFriendStatusMessage = function(friend, callback) {
 Tox.prototype.getFriendStatusMessageSync = function(friend) {
   return this._performFriendGetter({
     api: this.getLibrary().tox_friend_get_status_message.bind(undefined, this.getHandle()),
-    format: 'string',
+    format: "string",
     friend: friend,
     size: consts.TOX_MAX_STATUS_MESSAGE_LENGTH
   });
@@ -1813,7 +1813,7 @@ Tox.prototype.getSavedataSizeSync = function(callback) {
 Tox.prototype.getSavedata = function(callback) {
   this._performGetter({
     api: this.getLibrary().tox_get_savedata.async.bind(undefined, this.getHandle()),
-    format: 'raw',
+    format: "raw",
     size: Tox.prototype.getSavedataSize.bind(this),
     async: true, callback: callback
   });
@@ -1826,7 +1826,7 @@ Tox.prototype.getSavedata = function(callback) {
 Tox.prototype.getSavedataSync = function() {
   return this._performGetter({
     api: this.getLibrary().tox_get_savedata.bind(undefined, this.getHandle()),
-    format: 'raw',
+    format: "raw",
     size: Tox.prototype.getSavedataSizeSync.bind(this)
   });
 };
@@ -1998,7 +1998,7 @@ Tox.prototype.saveToFileSync = function(filepath) {
  * Start an interateSync loop using setInterval.
  * @param {Number} [wait] - Milliseconds to wait between iterateSync calls
  * @todo Maybe do one iterateSync(), then iterationIntervalSync(), and use that
- *       value as 'wait'?
+ *       value as "wait"?
  */
 Tox.prototype.start = function(wait) {
   if(!this.isStarted()) {
@@ -2091,8 +2091,8 @@ Tox.prototype.getSecretKeyHexSync = function() {
  */
 Tox.prototype._checkHandle = function(callback) {
   if(!this.hasHandle()) {
-    var err = new Error('No toxcore handle');
-    err.code = 'NO_HANDLE';
+    var err = new Error("No toxcore handle");
+    err.code = "NO_HANDLE";
     if(callback) {
       callback(err);
     }
@@ -2112,8 +2112,8 @@ Tox.prototype._checkHandle = function(callback) {
  */
 Tox.prototype._checkHandleSync = function() {
   if(!this.hasHandle()) {
-    var err = new Error('No toxcore handle');
-    err.code = 'NO_HANDLE';
+    var err = new Error("No toxcore handle");
+    err.code = "NO_HANDLE";
     throw err;
   }
 };
@@ -2129,12 +2129,12 @@ Tox.prototype._checkHandleSync = function() {
  */
 Tox.prototype._createToxOptions = function(opts) {
   var toxopts = this.newOptionsSync(),
-      ipv6 = opts['ipv6'],
-      udp = opts['udp'],
-      startPort = opts['startPort'],
-      endPort = opts['endPort'],
-      data = opts['data'],
-      pass = opts['pass'];
+      ipv6 = opts["ipv6"],
+      udp = opts["udp"],
+      startPort = opts["startPort"],
+      endPort = opts["endPort"],
+      data = opts["data"],
+      pass = opts["pass"];
 
   // If pass is a string or Buffer, have pass be a function that returns
   // the string or Buffer
@@ -2143,7 +2143,7 @@ Tox.prototype._createToxOptions = function(opts) {
     pass = function() { return passData; };
   }
 
-  // If 'data' is a string, assume filepath to read data from
+  // If "data" is a string, assume filepath to read data from
   if(_.isString(data)) {
     data = fs.readFileSync(data);
   }
@@ -2207,7 +2207,7 @@ Tox.prototype._fixBootstrapArgs = function(address, port, publicKey) {
   address = Buffer.from(address + '\0');
 
   if(_.isString(publicKey)) {
-    publicKey = (Buffer.from(publicKey, 'hex'));
+    publicKey = (Buffer.from(publicKey, "hex"));
   }
 
   return [address, port, publicKey];
@@ -2237,7 +2237,7 @@ Tox.prototype._fixSendMessageArgs = function(to, message, type) {
 
 /**
  * Fix a control file value. If a string, convert to its numeric value
- * ('resume', 'pause', 'cancel').
+ * ("resume", "pause", "cancel").
  * @private
  * @param {(Number|String)} control
  * @return {Number} control value
@@ -2284,7 +2284,7 @@ Tox.prototype._fixPacketBuffer = function(id, data) {
  * @private
  */
 Tox.prototype._initCrypto = function(opts) {
-  var crypto = opts['crypto'];
+  var crypto = opts["crypto"];
   if(crypto === undefined || crypto === true) {
     // If not given, use a default instance
     this._crypto = new ToxEncryptSave();
@@ -2332,7 +2332,7 @@ Tox.prototype._initNew = function(options, data) {
  * @todo Update for char* proxy_host, instead of char[256] proxy_host
  */
 Tox.prototype._setProxyToToxOptions = function(opts, options) {
-  var proxy = opts['proxy'];
+  var proxy = opts["proxy"];
 
   if(_.isString(proxy)) {
     proxy = util.parseProxy(proxy);
@@ -2349,7 +2349,7 @@ Tox.prototype._setProxyToToxOptions = function(opts, options) {
       // Set address, max string length 255
       // @todo Enforce 255 max length
       if(_.isString(proxy.address)) {
-        // Store in 'this' so it isn't GC-d?
+        // Store in "this' so it isn"t GC-d?
         this._proxyAddress = Buffer.from(proxy.address + '\0');
         options.proxy_address = this._proxyAddress;
       }
@@ -2399,15 +2399,15 @@ Tox.prototype._toFFICallback = function(ffiFunc, callback) {
  * @private
  */
 Tox.prototype._performBootstrap = function(opts) {
-  var api = opts['api'],
-      args = opts['args'],
-      async = opts['async'], callback = opts['callback'],
+  var api = opts["api"],
+      args = opts["args"],
+      async = opts["async"], callback = opts["callback"],
       address = args[0], port = args[1], publicKey = args[2];
 
   // Fix address and public key
   address = Buffer.from(address + '\0');
   if(_.isString(publicKey)) {
-    publicKey = (Buffer.from(publicKey,'hex'));
+    publicKey = (Buffer.from(publicKey,"hex"));
   }
 
   var eptr = ref.alloc(TOX_ERR_BOOTSTRAP);
@@ -2438,11 +2438,11 @@ Tox.prototype._performBootstrap = function(opts) {
  * @private
  */
 Tox.prototype._performFriendGetter = function(opts) {
-  var api = opts['api'],
-      friend = opts['friend'],
-      raw = (opts['format'] === 'raw'),
-      _size = opts['size'],
-      async = opts['async'], callback = opts['callback'];
+  var api = opts["api"],
+      friend = opts["friend"],
+      raw = (opts["format"] === "raw"),
+      _size = opts["size"],
+      async = opts["async"], callback = opts["callback"];
 
   if(_.isNumber(_size)) {
     var size;
@@ -2462,7 +2462,7 @@ Tox.prototype._performFriendGetter = function(opts) {
           var terr = errors.friendQuery(eptr.deref());
           if(!err && terr) err = terr;
           if(!err && !success) err = errors.unsuccessful();
-          if(!err && !raw) buffer = buffer.toString('utf8');
+          if(!err && !raw) buffer = buffer.toString("utf8");
           if(callback) {
             callback(err, buffer);
           }
@@ -2480,7 +2480,7 @@ Tox.prototype._performFriendGetter = function(opts) {
     var err = errors.friendQuery(eptr.deref());
     if(err) throw err;
     if(!success) throw errors.unsuccessful();
-    if(!raw) buffer = buffer.toString('utf8');
+    if(!raw) buffer = buffer.toString("utf8");
     return buffer;
   }
 };
@@ -2491,9 +2491,9 @@ Tox.prototype._performFriendGetter = function(opts) {
  * @private
  */
 Tox.prototype._performFriendNumberGetter = function(opts) {
-  var api = opts['api'],
-      friend = opts['friend'],
-      async = opts['async'], callback = opts['callback'];
+  var api = opts["api"],
+      friend = opts["friend"],
+      async = opts["async"], callback = opts["callback"];
 
   var eptr = ref.alloc(TOX_ERR_FRIEND_QUERY);
 
@@ -2525,10 +2525,10 @@ Tox.prototype._performFriendNumberGetter = function(opts) {
  * @private
  */
 Tox.prototype._performGetter = function(opts) {
-  var api = opts['api'],
-      raw = (opts['format'] === 'raw'),
-      _size = opts['size'],
-      async = opts['async'], callback = opts['callback'];
+  var api = opts["api"],
+      raw = (opts["format"] === "raw"),
+      _size = opts["size"],
+      async = opts["async"], callback = opts["callback"];
 
   if(_.isNumber(_size)) {
     var size;
@@ -2542,7 +2542,7 @@ Tox.prototype._performGetter = function(opts) {
       if(!err) {
         var buffer = Buffer.alloc(size);
         api(buffer, function(err) {
-          if(!err && !raw) buffer = buffer.toString('utf8');
+          if(!err && !raw) buffer = buffer.toString("utf8");
           if(callback) {
             callback(err, buffer);
           }
@@ -2556,7 +2556,7 @@ Tox.prototype._performGetter = function(opts) {
     size = size();
     var buffer = Buffer.alloc(size);
     api(buffer);
-    if(!raw) buffer = buffer.toString('utf8');
+    if(!raw) buffer = buffer.toString("utf8");
     return buffer;
   }
 };
@@ -2566,8 +2566,8 @@ Tox.prototype._performGetter = function(opts) {
  * @private
  */
 Tox.prototype._performNumberGetter = function(opts) {
-  var api = opts['api'],
-      async = opts['async'], callback = opts['callback'];
+  var api = opts["api"],
+      async = opts["async"], callback = opts["callback"];
 
   if(async) {
     if(!this._checkHandle(callback)) return;
@@ -2588,9 +2588,9 @@ Tox.prototype._performNumberGetter = function(opts) {
  * @private
  */
 Tox.prototype._performNumberSetter = function(opts) {
-  var api = opts['api'],
-      value = opts['value'],
-      async = opts['async'], callback = opts['callback'];
+  var api = opts["api"],
+      value = opts["value"],
+      async = opts["async"], callback = opts["callback"];
 
   if(async) {
     if(!this._checkHandle(callback)) return;
@@ -2619,10 +2619,10 @@ Tox.prototype._performSizeGetter = function(opts) {
  * @private
  */
 Tox.prototype._performSetter = function(opts) {
-  var api = opts['api'],
-      data = opts['data'],
-      errorCheck = opts['error'],
-      async = opts['async'], callback = opts['callback'];
+  var api = opts["api"],
+      data = opts["data"],
+      errorCheck = opts["error"],
+      async = opts["async"], callback = opts["callback"];
 
   if(_.isString(data)) {
     data = Buffer.from(data);
@@ -2655,10 +2655,10 @@ Tox.prototype._performSetter = function(opts) {
  * @private
  */
 Tox.prototype._performSendPacket = function(opts) {
-  var api = opts['api'],
-      data = opts['data'],
-      friendnum = opts['friend'],
-      async = opts['async'], callback = opts['callback'];
+  var api = opts["api"],
+      data = opts["data"],
+      friendnum = opts["friend"],
+      async = opts["async"], callback = opts["callback"];
 
   var eptr = ref.alloc(TOX_ERR_FRIEND_CUSTOM_PACKET);
 
@@ -2686,8 +2686,8 @@ Tox.prototype._performSendPacket = function(opts) {
  * @private
  */
 Tox.prototype._performGetPort = function(opts) {
-  var api = opts['api'],
-      async = opts['async'], callback = opts['callback'];
+  var api = opts["api"],
+      async = opts["async"], callback = opts["callback"];
 
   var eptr = ref.alloc(TOX_ERR_GET_PORT);
 
@@ -2714,8 +2714,8 @@ Tox.prototype._performGetPort = function(opts) {
  * @private
  */
 Tox.prototype._performVersion = function(opts) {
-  var api = opts['api'],
-      async = opts['async'], callback = opts['callback'];
+  var api = opts["api"],
+      async = opts["async"], callback = opts["callback"];
   if(async) {
     api(function(err, version) {
       if(callback) {
@@ -2762,10 +2762,10 @@ Tox.prototype._initCallbacks = function() {
 Tox.prototype._initCallback = function(opts) {
   this._checkHandleSync();
 
-  var api = opts['api'],
-      cb = opts['cb'], // Callback type
-      name = opts['name'],
-      wrapper = opts['wrapper'];
+  var api = opts["api"],
+      cb = opts["cb"], // Callback type
+      name = opts["name"],
+      wrapper = opts["wrapper"];
 
   var x = this._toFFICallback(cb, wrapper);
   this._storeFFICallback(name, x); // Store for GC issues
@@ -2781,9 +2781,9 @@ Tox.prototype._initSelfConnectionStatusCb = function() {
   this._initCallback({
     api: this.getLibrary().tox_callback_self_connection_status.bind(undefined, this.getHandle()),
     cb: SelfConnectionStatusCallback,
-    name: 'SelfConnectionStatus',
+    name: "SelfConnectionStatus",
     wrapper: function(handle, connection, userdata) {
-      _this._emit('selfConnectionStatus', new toxEvents.SelfConnectionStatusEvent(connection));
+      _this._emit("selfConnectionStatus", new toxEvents.SelfConnectionStatusEvent(connection));
     }
   });
 };
@@ -2797,10 +2797,10 @@ Tox.prototype._initFriendNameCb = function() {
   this._initCallback({
     api: this.getLibrary().tox_callback_friend_name.bind(undefined, this.getHandle()),
     cb: FriendNameCallback,
-    name: 'FriendName',
+    name: "FriendName",
     wrapper: function(handle, friend, buffer, size, userdata) {
       var name = buffer.slice(0, size).toString();
-      _this._emit('friendName', new toxEvents.FriendNameEvent(friend, name));
+      _this._emit("friendName", new toxEvents.FriendNameEvent(friend, name));
     }
   });
 };
@@ -2814,10 +2814,10 @@ Tox.prototype._initFriendStatusMessageCb = function() {
   this._initCallback({
     api: this.getLibrary().tox_callback_friend_status_message.bind(undefined, this.getHandle()),
     cb: FriendStatusMessageCallback,
-    name: 'FriendStatusMessage',
+    name: "FriendStatusMessage",
     wrapper: function(handle, friend, buffer, size, userdata) {
       var statusMessage = buffer.slice(0, size).toString();
-      _this._emit('friendStatusMessage', new toxEvents.FriendStatusMessageEvent(friend, statusMessage));
+      _this._emit("friendStatusMessage", new toxEvents.FriendStatusMessageEvent(friend, statusMessage));
     }
   });
 };
@@ -2831,9 +2831,9 @@ Tox.prototype._initFriendStatusCb = function() {
   this._initCallback({
     api: this.getLibrary().tox_callback_friend_status.bind(undefined, this.getHandle()),
     cb: FriendStatusCallback,
-    name: 'FriendStatus',
+    name: "FriendStatus",
     wrapper: function(handle, friend, status, userdata) {
-      _this._emit('friendStatus', new toxEvents.FriendStatusEvent(friend, status));
+      _this._emit("friendStatus", new toxEvents.FriendStatusEvent(friend, status));
     }
   });
 };
@@ -2847,9 +2847,9 @@ Tox.prototype._initFriendConnectionStatusCb = function() {
   this._initCallback({
     api: this.getLibrary().tox_callback_friend_connection_status.bind(undefined, this.getHandle()),
     cb: FriendConnectionStatusCallback,
-    name: 'FriendConnectionStatus',
+    name: "FriendConnectionStatus",
     wrapper: function(handle, friend, connection, userdata) {
-      _this._emit('friendConnectionStatus', new toxEvents.FriendConnectionStatusEvent(friend, connection));
+      _this._emit("friendConnectionStatus", new toxEvents.FriendConnectionStatusEvent(friend, connection));
     }
   });
 };
@@ -2863,9 +2863,9 @@ Tox.prototype._initFriendTypingCb = function() {
   this._initCallback({
     api: this.getLibrary().tox_callback_friend_typing.bind(undefined, this.getHandle()),
     cb: FriendTypingCallback,
-    name: 'FriendTypingStatus',
+    name: "FriendTypingStatus",
     wrapper: function(handle, friend, typing, userdata) {
-      _this._emit('friendTyping', new toxEvents.FriendTypingEvent(friend, typing));
+      _this._emit("friendTyping", new toxEvents.FriendTypingEvent(friend, typing));
     }
   });
 };
@@ -2879,9 +2879,9 @@ Tox.prototype._initFriendReadReceiptCb = function() {
   this._initCallback({
     api: this.getLibrary().tox_callback_friend_read_receipt.bind(undefined, this.getHandle()),
     cb: FriendReadReceiptCallback,
-    name: 'FriendReadReceiptStatus',
+    name: "FriendReadReceiptStatus",
     wrapper: function(handle, friend, receipt, userdata) {
-      _this._emit('friendReadReceipt', new toxEvents.FriendReadReceiptEvent(friend, receipt));
+      _this._emit("friendReadReceipt", new toxEvents.FriendReadReceiptEvent(friend, receipt));
     }
   });
 };
@@ -2895,11 +2895,11 @@ Tox.prototype._initFriendRequestCb = function() {
   this._initCallback({
     api: this.getLibrary().tox_callback_friend_request.bind(undefined, this.getHandle()),
     cb: FriendRequestCallback,
-    name: 'FriendRequestStatus',
+    name: "FriendRequestStatus",
     wrapper: function(handle, publicKey, data, size, userdata) {
       publicKey = Buffer.from(publicKey); // Copy into persistent Buffer
       var message = data.slice(0, size).toString();
-      _this._emit('friendRequest', new toxEvents.FriendRequestEvent(publicKey, message));
+      _this._emit("friendRequest", new toxEvents.FriendRequestEvent(publicKey, message));
     }
   });
 };
@@ -2913,10 +2913,10 @@ Tox.prototype._initFriendMessageCb = function() {
   this._initCallback({
     api: this.getLibrary().tox_callback_friend_message.bind(undefined, this.getHandle()),
     cb: FriendMessageCallback,
-    name: 'FriendMessage',
+    name: "FriendMessage",
     wrapper: function(handle, friend, type, data, size, userdata) {
       var message = data.slice(0, size).toString();
-      _this._emit('friendMessage', new toxEvents.FriendMessageEvent(friend, type, message));
+      _this._emit("friendMessage", new toxEvents.FriendMessageEvent(friend, type, message));
     }
   });
 };
@@ -2930,9 +2930,9 @@ Tox.prototype._initFileRecvControlCb = function() {
   this._initCallback({
     api: this.getLibrary().tox_callback_file_recv_control.bind(undefined, this.getHandle()),
     cb: FileRecvControlCallback,
-    name: 'FileRecvControlCallback',
+    name: "FileRecvControlCallback",
     wrapper: function(handle, friend, file, control, userdata) {
-      _this._emit('fileRecvControl', new toxEvents.FileRecvControlEvent(friend, file, control));
+      _this._emit("fileRecvControl", new toxEvents.FileRecvControlEvent(friend, file, control));
     }
   });
 };
@@ -2946,9 +2946,9 @@ Tox.prototype._initFileChunkRequestCb = function() {
   this._initCallback({
     api: this.getLibrary().tox_callback_file_chunk_request.bind(undefined, this.getHandle()),
     cb: FileChunkRequestCallback,
-    name: 'FileChunkRequestCallback',
+    name: "FileChunkRequestCallback",
     wrapper: function(handle, friend, file, position, length, userdata) {
-      _this._emit('fileChunkRequest', new toxEvents.FileChunkRequestEvent(friend, file, position, length));
+      _this._emit("fileChunkRequest", new toxEvents.FileChunkRequestEvent(friend, file, position, length));
     }
   });
 };
@@ -2962,15 +2962,15 @@ Tox.prototype._initFileRecvCb = function() {
   this._initCallback({
     api: this.getLibrary().tox_callback_file_recv.bind(undefined, this.getHandle()),
     cb: FileRecvCallback,
-    name: 'FileRecvCallback',
+    name: "FileRecvCallback",
     wrapper: function(handle, friend, file, kind, size, filename, length, userdata) {
       // Filename might be NULL, probably if file kind is AVATAR or non-DATA
       if(ref.address(filename) !== 0) {
-        filename = (ref.reinterpret(filename, length)).toString('utf8');
+        filename = (ref.reinterpret(filename, length)).toString("utf8");
       } else {
         filename = undefined;
       }
-      _this._emit('fileRecv', new toxEvents.FileRecvEvent(friend, file, kind, size, filename));
+      _this._emit("fileRecv", new toxEvents.FileRecvEvent(friend, file, kind, size, filename));
     }
   });
 };
@@ -2984,7 +2984,7 @@ Tox.prototype._initFileRecvChunkCb = function() {
   this._initCallback({
     api: this.getLibrary().tox_callback_file_recv_chunk.bind(undefined, this.getHandle()),
     cb: FileRecvChunkCallback,
-    name: 'FileRecvChunkCallback',
+    name: "FileRecvChunkCallback",
     wrapper: function(handle, friend, file, position, data, size, userdata) {
       // Apparently data can sometimes be a NULL pointer, set data to undefined if so
       // This should only happen on final chunk?
@@ -2993,7 +2993,7 @@ Tox.prototype._initFileRecvChunkCb = function() {
       } else {
         data = undefined;
       }
-      _this._emit('fileRecvChunk', new toxEvents.FileRecvChunkEvent(friend, file, position, data));
+      _this._emit("fileRecvChunk", new toxEvents.FileRecvChunkEvent(friend, file, position, data));
     }
   });
 };
@@ -3007,7 +3007,7 @@ Tox.prototype._initFriendLosslessPacketCb = function() {
   this._initCallback({
     api: this.getLibrary().tox_callback_friend_lossless_packet.bind(undefined, this.getHandle()),
     cb: FriendLosslessPacketCallback,
-    name: 'FriendLosslessPacketCallback',
+    name: "FriendLosslessPacketCallback",
     wrapper: function(handle, friend, data, length, userdata) {
       //if(ref.address(data) !== 0) {
       //  //first byte is magic byte(160) so ignore it
@@ -3020,7 +3020,7 @@ Tox.prototype._initFriendLosslessPacketCb = function() {
       } else {
         data = undefined;
       }
-      _this._emit('friendLosslessPacket', new toxEvents.FriendPacketEvent(friend, data, true));
+      _this._emit("friendLosslessPacket", new toxEvents.FriendPacketEvent(friend, data, true));
     }
   });
 }
@@ -3034,14 +3034,14 @@ Tox.prototype._initFriendLossyPacketCb = function() {
   this._initCallback({
     api: this.getLibrary().tox_callback_friend_lossy_packet.bind(undefined, this.getHandle()),
     cb: FriendLossyPacketCallback,
-    name: 'FriendLossyPacketCallback',
+    name: "FriendLossyPacketCallback",
     wrapper: function(handle, friend, data, length, userdata) {
       if(ref.address(data) !== 0) {
         data = Buffer.from(ref.reinterpret(data, length));
       } else {
         data = undefined;
       }
-      _this._emit('friendLossyPacket', new toxEvents.FriendPacketEvent(friend, data, false));
+      _this._emit("friendLossyPacket", new toxEvents.FriendPacketEvent(friend, data, false));
     }
   });
 }

--- a/lib/tox.js
+++ b/lib/tox.js
@@ -25,7 +25,6 @@
  *       function to set the data to that Buffer.
  */
 
-var buffertools = require('buffertools');
 var events = require('events');
 var fs = require('fs');
 var ref = require('ref');
@@ -35,7 +34,7 @@ var path = require('path');
 var _ = require('underscore');
 var _util = require('util');
 
-buffertools.extend();
+require("buffer")
 
 var consts = require(path.join(__dirname, 'consts'));
 var errors = require(path.join(__dirname, 'errors'));
@@ -2264,7 +2263,7 @@ Tox.prototype._fixFileControl = function(control) {
  */
 Tox.prototype._fixSendLosslessPacket = function(data){
   //160: magic byte
-  return buffertools.concat(new Buffer([160]), data);
+  return Buffer.concat([new Buffer([160]), data]);
 };
 
 /**
@@ -2276,7 +2275,7 @@ Tox.prototype._fixSendLosslessPacket = function(data){
  * @return {Buffer} new data
  */
 Tox.prototype._fixPacketBuffer = function(id, data) {
-  return buffertools.concat(new Buffer([id]), data);
+  return Buffer.concat([new Buffer([id]), data]);
 };
 
 /**

--- a/lib/tox.js
+++ b/lib/tox.js
@@ -832,7 +832,9 @@ Tox.prototype.addFriend = function(address, message, callback) {
   if(!this._checkHandle(callback)) return;
 
   address = fromHex(address);
-  if(_.isString(message)) message = Buffer.from(message);
+  if(_.isString(message)) {
+    message = Buffer.from(message);
+  }
 
   var eptr = ref.alloc(TOX_ERR_FRIEND_ADD);
   this.getLibrary().tox_friend_add.async(

--- a/lib/tox.js
+++ b/lib/tox.js
@@ -85,6 +85,8 @@ var TOX_ERR_OPTIONS_NEW = CEnum;
 var TOX_ERR_SET_INFO = CEnum;
 var TOX_ERR_SET_TYPING = CEnum;
 
+
+
 // Buffer sizes for callbacks
 var KeyBuffer = RefArray("uint8", consts.TOX_KEY_SIZE);
 var KeyBufferPtr = ref.refType(KeyBuffer);
@@ -148,7 +150,8 @@ Tox.prototype.inspect = function() {
     // Hacky fix for StringSlice assert error:
     // void node::Buffer::StringSlice(const v8::FunctionCallbackInfo<v8::Value>&) [with node::encoding encoding = (node::encoding)5u]: Assertion `obj_data != __null' failed.
     if(k === "_options") {
-      obj[k] = "[ToxOptions]";
+      // linting is weird and wants us to specifically `.toString()` this
+      obj[k.toString()] = "[ToxOptions]";
     }
   }, this);
   return _util.inspect(obj);
@@ -852,7 +855,9 @@ Tox.prototype.addFriendSync = function(address, message) {
   this._checkHandleSync();
 
   address = fromHex(address);
-  if(_.isString(message)) message = Buffer.from(message);
+  if(_.isString(message)) {
+    message = Buffer.from(message);
+  }
 
   var eptr = ref.alloc(TOX_ERR_FRIEND_ADD),
       friend = this.getLibrary().tox_friend_add(

--- a/lib/tox.js
+++ b/lib/tox.js
@@ -36,14 +36,14 @@ var _util = require("util");
 
 require("buffer");
 
-var consts = require(path.join(__dirname, "consts"));
-var errors = require(path.join(__dirname, "errors"));
-var toxEvents = require(path.join(__dirname, "events"));
-var ToxEncryptSave = require(path.join(__dirname, "toxencryptsave"));
-var ToxOptions = require(path.join(__dirname, "toxoptions"));
+var consts = require("./consts");
+var errors = require("./errors");
+var toxEvents = require("./events");
+var ToxEncryptSave = require("./toxencryptsave");
+var ToxOptions = require("./toxoptions");
 
 // Util functions
-var util = require(path.join(__dirname, "util"));
+var util = require("./util");
 var size_t = util.size_t;
 var fromHex = util.fromHex;
 var getDateFromUInt64 = util.getDateFromUInt64;
@@ -1099,7 +1099,7 @@ Tox.prototype.getFriendList = function(callback) {
         _this.getHandle(), arr.buffer, function(err) {
 
         // RefArray -> Javascript Array
-        // @todo Make this refArrayToArray()?
+        // @todo Make this RefArrayToArray()?
         var nums = [];
         if(!err) {
           for(var i = 0; i < arr.length; i++)

--- a/lib/tox.js
+++ b/lib/tox.js
@@ -829,7 +829,7 @@ Tox.prototype.addFriend = function(address, message, callback) {
   if(!this._checkHandle(callback)) return;
 
   address = fromHex(address);
-  if(_.isString(message)) message = new Buffer(message);
+  if(_.isString(message)) message = Buffer.from(message);
 
   var eptr = ref.alloc(TOX_ERR_FRIEND_ADD);
   this.getLibrary().tox_friend_add.async(
@@ -852,7 +852,7 @@ Tox.prototype.addFriendSync = function(address, message) {
   this._checkHandleSync();
 
   address = fromHex(address);
-  if(_.isString(message)) message = new Buffer(message);
+  if(_.isString(message)) message = Buffer.from(message);
 
   var eptr = ref.alloc(TOX_ERR_FRIEND_ADD),
       friend = this.getLibrary().tox_friend_add(
@@ -970,7 +970,7 @@ Tox.prototype.getFriendByPublicKeySync = function(publicKey) {
 Tox.prototype.getFriendPublicKey = function(friend, callback) {
   if(!this._checkHandle(callback)) return;
   var eptr = ref.alloc(TOX_ERR_FRIEND_GET_PUBLIC_KEY),
-      buffer = new Buffer(consts.TOX_PUBLIC_KEY_SIZE);
+      buffer = Buffer.alloc(consts.TOX_PUBLIC_KEY_SIZE);
   this.getLibrary().tox_friend_get_public_key.async(
     this.getHandle(), friend, buffer, eptr, function(err, friend) {
     var terr = errors.friendGetPublicKey(eptr.deref());
@@ -989,7 +989,7 @@ Tox.prototype.getFriendPublicKey = function(friend, callback) {
 Tox.prototype.getFriendPublicKeySync = function(friend) {
   this._checkHandle();
   var eptr = ref.alloc(TOX_ERR_FRIEND_GET_PUBLIC_KEY),
-      buffer = new Buffer(consts.TOX_PUBLIC_KEY_SIZE),
+      buffer = Buffer.alloc(consts.TOX_PUBLIC_KEY_SIZE),
       success = this.getLibrary().tox_friend_get_public_key(this.getHandle(), friend, buffer, eptr);
   var err = errors.friendGetPublicKey(eptr.deref());
   if(err) throw err;
@@ -1432,8 +1432,8 @@ Tox.prototype.sendFriendMessageSync = function(friend, message, type) {
  * @param {Tox~dataCallback} [callback]
  */
 Tox.prototype.hash = function(data, callback) {
-  if(_.isString(data)) data = new Buffer(data);
-  var hash = new Buffer(consts.TOX_HASH_LENGTH);
+  if(_.isString(data)) data = Buffer.from(data);
+  var hash = Buffer.alloc(consts.TOX_HASH_LENGTH);
   this.getLibrary().tox_hash.async(hash, data, data.length,
     function(err, success) {
     if(!err && !success) err = errors.unsuccessful();
@@ -1449,8 +1449,8 @@ Tox.prototype.hash = function(data, callback) {
  * @return {Buffer} hash
  */
 Tox.prototype.hashSync = function(data) {
-  if(_.isString(data)) data = new Buffer(data);
-  var hash = new Buffer(consts.TOX_HASH_LENGTH),
+  if(_.isString(data)) data = Buffer.from(data);
+  var hash = Buffer.alloc(consts.TOX_HASH_LENGTH),
       success = this.getLibrary().tox_hash(hash, data, data.length);
   if(!success) throw errors.unsuccessful();
   return hash;
@@ -1541,7 +1541,7 @@ Tox.prototype.seekFileSync = function(friendnum, filenum, position) {
 Tox.prototype.getFileId = function(friendnum, filenum, callback) {
   if(!this._checkHandle(callback)) return;
   var eptr = ref.alloc(TOX_ERR_FILE_GET),
-      fileid = new Buffer(consts.TOX_FILE_ID_LENGTH);
+      fileid = Buffer.alloc(consts.TOX_FILE_ID_LENGTH);
   this.getLibrary().tox_file_get_file_id.async(
     this.getHandle(), friendnum, filenum, fileid, eptr, function(err, success) {
     var terr = errors.fileGet(eptr.deref());
@@ -1562,7 +1562,7 @@ Tox.prototype.getFileId = function(friendnum, filenum, callback) {
 Tox.prototype.getFileIdSync = function(friendnum, filenum) {
   this._checkHandleSync();
   var eptr = ref.alloc(TOX_ERR_FILE_GET),
-      fileid = new Buffer(consts.TOX_FILE_ID_LENGTH),
+      fileid = Buffer.alloc(consts.TOX_FILE_ID_LENGTH),
       success = this.getLibrary().tox_file_get_file_id(
         this.getHandle(), friendnum, filenum, fileid, eptr);
   var err = errors.fileGet(eptr.deref());
@@ -1588,7 +1588,7 @@ Tox.prototype.sendFile = function(friendnum, kind, filename, size, fileid, callb
   }
   if(!fileid) fileid = ref.NULL;
   if(_.isString(filename)) {
-    filename = new Buffer(filename);
+    filename = Buffer.from(filename);
   }
   var eptr = ref.alloc(TOX_ERR_FILE_SEND);
   this.getLibrary().tox_file_send.async(
@@ -1614,7 +1614,7 @@ Tox.prototype.sendFileSync = function(friendnum, kind, filename, size, fileid) {
   this._checkHandleSync();
   if(!fileid) fileid = ref.NULL;
   if(_.isString(filename)) {
-    filename = new Buffer(filename);
+    filename = Buffer.from(filename);
   }
   var eptr = ref.alloc(TOX_ERR_FILE_SEND);
       filenum = this.getLibrary().tox_file_send(
@@ -2204,10 +2204,10 @@ Tox.prototype._emit = function() {
  * @private
  */
 Tox.prototype._fixBootstrapArgs = function(address, port, publicKey) {
-  address = new Buffer(address + '\0');
+  address = Buffer.from(address + '\0');
 
   if(_.isString(publicKey)) {
-    publicKey = (new Buffer(publicKey)).fromHex();
+    publicKey = (Buffer.from(publicKey, 'hex'));
   }
 
   return [address, port, publicKey];
@@ -2219,7 +2219,7 @@ Tox.prototype._fixBootstrapArgs = function(address, port, publicKey) {
  */
 Tox.prototype._fixSendMessageArgs = function(to, message, type) {
   if(_.isString(message)) {
-    message = (new Buffer(message));
+    message = (Buffer.from(message));
   }
 
   if(_.isBoolean(type)) {
@@ -2263,7 +2263,7 @@ Tox.prototype._fixFileControl = function(control) {
  */
 Tox.prototype._fixSendLosslessPacket = function(data){
   //160: magic byte
-  return Buffer.concat([new Buffer([160]), data]);
+  return Buffer.concat([Buffer.from([160]), data]);
 };
 
 /**
@@ -2275,7 +2275,7 @@ Tox.prototype._fixSendLosslessPacket = function(data){
  * @return {Buffer} new data
  */
 Tox.prototype._fixPacketBuffer = function(id, data) {
-  return Buffer.concat([new Buffer([id]), data]);
+  return Buffer.concat([Buffer.from([id]), data]);
 };
 
 /**
@@ -2350,7 +2350,7 @@ Tox.prototype._setProxyToToxOptions = function(opts, options) {
       // @todo Enforce 255 max length
       if(_.isString(proxy.address)) {
         // Store in 'this' so it isn't GC-d?
-        this._proxyAddress = new Buffer(proxy.address + '\0');
+        this._proxyAddress = Buffer.from(proxy.address + '\0');
         options.proxy_address = this._proxyAddress;
       }
 
@@ -2405,9 +2405,9 @@ Tox.prototype._performBootstrap = function(opts) {
       address = args[0], port = args[1], publicKey = args[2];
 
   // Fix address and public key
-  address = new Buffer(address + '\0');
+  address = Buffer.from(address + '\0');
   if(_.isString(publicKey)) {
-    publicKey = (new Buffer(publicKey)).fromHex();
+    publicKey = (Buffer.from(publicKey,'hex'));
   }
 
   var eptr = ref.alloc(TOX_ERR_BOOTSTRAP);
@@ -2456,7 +2456,7 @@ Tox.prototype._performFriendGetter = function(opts) {
     if(!this._checkHandle(callback)) return;
     size(function(err, size) {
       if(!err) {
-        var buffer = new Buffer(size);
+        var buffer = Buffer.alloc(size);
         buffer.fill(0);
         api(friend, buffer, eptr, function(err, success) {
           var terr = errors.friendQuery(eptr.deref());
@@ -2474,7 +2474,7 @@ Tox.prototype._performFriendGetter = function(opts) {
   } else {
     this._checkHandleSync();
     size = size();
-    var buffer = new Buffer(size);
+    var buffer = Buffer.alloc(size);
     buffer.fill(0);
     var success = api(friend, buffer, eptr);
     var err = errors.friendQuery(eptr.deref());
@@ -2540,7 +2540,7 @@ Tox.prototype._performGetter = function(opts) {
     if(!this._checkHandle(callback)) return;
     size(function(err, size) {
       if(!err) {
-        var buffer = new Buffer(size);
+        var buffer = Buffer.alloc(size);
         api(buffer, function(err) {
           if(!err && !raw) buffer = buffer.toString('utf8');
           if(callback) {
@@ -2554,7 +2554,7 @@ Tox.prototype._performGetter = function(opts) {
   } else {
     this._checkHandleSync();
     size = size();
-    var buffer = new Buffer(size);
+    var buffer = Buffer.alloc(size);
     api(buffer);
     if(!raw) buffer = buffer.toString('utf8');
     return buffer;
@@ -2625,7 +2625,7 @@ Tox.prototype._performSetter = function(opts) {
       async = opts['async'], callback = opts['callback'];
 
   if(_.isString(data)) {
-    data = new Buffer(data);
+    data = Buffer.from(data);
   }
 
   var eptr = ref.alloc(CEnum); // @todo: Make this more specific?
@@ -2897,7 +2897,7 @@ Tox.prototype._initFriendRequestCb = function() {
     cb: FriendRequestCallback,
     name: 'FriendRequestStatus',
     wrapper: function(handle, publicKey, data, size, userdata) {
-      publicKey = new Buffer(publicKey); // Copy into persistent Buffer
+      publicKey = Buffer.from(publicKey); // Copy into persistent Buffer
       var message = data.slice(0, size).toString();
       _this._emit('friendRequest', new toxEvents.FriendRequestEvent(publicKey, message));
     }
@@ -2989,7 +2989,7 @@ Tox.prototype._initFileRecvChunkCb = function() {
       // Apparently data can sometimes be a NULL pointer, set data to undefined if so
       // This should only happen on final chunk?
       if(ref.address(data) !== 0) {
-        data = new Buffer(ref.reinterpret(data, size)); // Copy to another Buffer
+        data = Buffer.from(ref.reinterpret(data, size)); // Copy to another Buffer
       } else {
         data = undefined;
       }
@@ -3011,12 +3011,12 @@ Tox.prototype._initFriendLosslessPacketCb = function() {
     wrapper: function(handle, friend, data, length, userdata) {
       //if(ref.address(data) !== 0) {
       //  //first byte is magic byte(160) so ignore it
-      //  data = new Buffer(ref.reinterpret(data, (length - 1), 1)); // Copy to another Buffer
+      //  data = Buffer.from(ref.reinterpret(data, (length - 1), 1)); // Copy to another Buffer
       //} else {
       //  data = undefined;
       //}
       if(ref.address(data) !== 0) {
-        data = new Buffer(ref.reinterpret(data, length));
+        data = Buffer.from(ref.reinterpret(data, length));
       } else {
         data = undefined;
       }
@@ -3037,7 +3037,7 @@ Tox.prototype._initFriendLossyPacketCb = function() {
     name: 'FriendLossyPacketCallback',
     wrapper: function(handle, friend, data, length, userdata) {
       if(ref.address(data) !== 0) {
-        data = new Buffer(ref.reinterpret(data, length));
+        data = Buffer.from(ref.reinterpret(data, length));
       } else {
         data = undefined;
       }

--- a/lib/tox.js
+++ b/lib/tox.js
@@ -27,9 +27,9 @@
 
 var events = require('events');
 var fs = require('fs');
-var ref = require('ref');
-var RefArray = require('ref-array');
-var ffi = require('ffi');
+var ref = require('ref-napi');
+var RefArray = require('ref-array-napi');
+var ffi = require('ffi-napi');
 var path = require('path');
 var _ = require('underscore');
 var _util = require('util');

--- a/lib/toxencryptsave.js
+++ b/lib/toxencryptsave.js
@@ -83,9 +83,9 @@ ToxEncryptSave.prototype._createLibrary = function(libpath) {
  * @param {ToxEncryptSave~dataCallback} [callback]
  */
 ToxEncryptSave.prototype.decrypt = function(data, pass, callback) {
-  if(_.isString(pass)) pass = new Buffer(pass);
+  if(_.isString(pass)) pass = Buffer.from(pass);
   var eptr = ref.alloc(TOX_ERR_DECRYPTION),
-      out = new Buffer(data.length - consts.TOX_PASS_ENCRYPTION_EXTRA_LENGTH);
+      out = Buffer.alloc(data.length - consts.TOX_PASS_ENCRYPTION_EXTRA_LENGTH);
   this.getLibrary().tox_pass_decrypt.async(data, data.length, pass, pass.length, out, eptr, function(err, success) {
     var terr = errors.decryption(eptr.deref());
     if(!err && terr) err = terr;
@@ -103,9 +103,9 @@ ToxEncryptSave.prototype.decrypt = function(data, pass, callback) {
  * @return {Buffer} Decrypted data
  */
 ToxEncryptSave.prototype.decryptSync = function(data, pass) {
-  if(_.isString(pass)) pass = new Buffer(pass);
+  if(_.isString(pass)) pass = Buffer.from(pass);
   var eptr = ref.alloc(TOX_ERR_DECRYPTION),
-      out = new Buffer(data.length - consts.TOX_PASS_ENCRYPTION_EXTRA_LENGTH),
+      out = Buffer.alloc(data.length - consts.TOX_PASS_ENCRYPTION_EXTRA_LENGTH),
       success = this.getLibrary().tox_pass_decrypt(data, data.length, pass, pass.length, out, eptr);
   var err = errors.decryption(eptr.deref());
   if(err) throw err;
@@ -120,9 +120,9 @@ ToxEncryptSave.prototype.decryptSync = function(data, pass) {
  * @param {ToxEncryptSave~dataCallback} [callback]
  */
 ToxEncryptSave.prototype.encrypt = function(data, pass, callback) {
-  if(_.isString(pass)) pass = new Buffer(pass);
+  if(_.isString(pass)) pass = Buffer.from(pass);
   var eptr = ref.alloc(TOX_ERR_ENCRYPTION),
-      out = new Buffer(data.length + consts.TOX_PASS_ENCRYPTION_EXTRA_LENGTH);
+      out = Buffer.alloc(data.length + consts.TOX_PASS_ENCRYPTION_EXTRA_LENGTH);
   this.getLibrary().tox_pass_encrypt.async(data, data.length, pass, pass.length, out, eptr, function(err, success) {
     var terr = errors.encryption(eptr.deref());
     if(!err && terr) err = terr;
@@ -140,9 +140,9 @@ ToxEncryptSave.prototype.encrypt = function(data, pass, callback) {
  * @return {Buffer} Encrypted data
  */
 ToxEncryptSave.prototype.encryptSync = function(data, pass) {
-  if(_.isString(pass)) pass = new Buffer(pass);
+  if(_.isString(pass)) pass = Buffer.from(pass);
   var eptr = ref.alloc(TOX_ERR_ENCRYPTION),
-      out = new Buffer(data.length + consts.TOX_PASS_ENCRYPTION_EXTRA_LENGTH),
+      out = Buffer.alloc(data.length + consts.TOX_PASS_ENCRYPTION_EXTRA_LENGTH),
       success = this.getLibrary().tox_pass_encrypt(data, data.length, pass, pass.length, out, eptr);
   var err = errors.encryption(eptr.deref());
   if(err) throw err;
@@ -156,7 +156,7 @@ ToxEncryptSave.prototype.encryptSync = function(data, pass) {
  * @param {ToxEncryptSave~dataCallback} [callback]
  */
 ToxEncryptSave.prototype.getSalt = function(data, callback) {
-  var salt = new Buffer(consts.TOX_PASS_SALT_LENGTH),
+  var salt = Buffer.alloc(consts.TOX_PASS_SALT_LENGTH),
       eptr = ref.alloc(TOX_ERR_GET_SALT);
   this.getLibrary().tox_get_salt.async(data, salt, eptr, function(err, success) {
     if(!err && !success) err = errors.unsuccessful();
@@ -172,7 +172,7 @@ ToxEncryptSave.prototype.getSalt = function(data, callback) {
  * @return {Buffer} Salt
  */
 ToxEncryptSave.prototype.getSaltSync = function(data) {
-  var salt = new Buffer(consts.TOX_PASS_SALT_LENGTH),
+  var salt = Buffer.alloc(consts.TOX_PASS_SALT_LENGTH),
       eptr = ref.alloc(TOX_ERR_GET_SALT),
       success = this.getLibrary().tox_get_salt(data, salt, eptr);
   if(!success) throw errors.unsuccessful();
@@ -266,7 +266,7 @@ ToxEncryptSave.prototype.deriveKeyWithSaltSync = function(pass, salt) {
  * @param {ToxEncryptSave~dataCallback} [callback]
  */
 ToxEncryptSave.prototype.encryptPassKey = function(data, passKey, callback) {
-  var out = new Buffer(data.length + consts.TOX_PASS_ENCRYPTION_EXTRA_LENGTH),
+  var out = Buffer.alloc(data.length + consts.TOX_PASS_ENCRYPTION_EXTRA_LENGTH),
       eptr = ref.alloc(TOX_ERR_ENCRYPTION);
   this.getLibrary().tox_pass_key_encrypt.async(passKey.ref(), data, data.length, out, eptr, function(err, success) {
     var terr = errors.encryption(eptr.deref());
@@ -285,7 +285,7 @@ ToxEncryptSave.prototype.encryptPassKey = function(data, passKey, callback) {
  * @return {Buffer} Encrypted data
  */
 ToxEncryptSave.prototype.encryptPassKeySync = function(data, passKey) {
-  var out = new Buffer(data.length + consts.TOX_PASS_ENCRYPTION_EXTRA_LENGTH),
+  var out = Buffer.alloc(data.length + consts.TOX_PASS_ENCRYPTION_EXTRA_LENGTH),
       eptr = ref.alloc(TOX_ERR_ENCRYPTION),
       success = this.getLibrary().tox_pass_key_encrypt(passKey.ref(), data, data.length, out, eptr);
   var err = errors.encryption(eptr.deref());
@@ -301,7 +301,7 @@ ToxEncryptSave.prototype.encryptPassKeySync = function(data, passKey) {
  * @param {ToxEncryptSave~dataCallback} [callback]
  */
 ToxEncryptSave.prototype.decryptPassKey = function(data, passKey, callback) {
-  var out = new Buffer(data.length - consts.TOX_PASS_ENCRYPTION_EXTRA_LENGTH),
+  var out = Buffer.alloc(data.length - consts.TOX_PASS_ENCRYPTION_EXTRA_LENGTH),
       eptr = ref.alloc(TOX_ERR_DECRYPTION);
   this.getLibrary().tox_pass_key_decrypt.async(passKey.ref(), data, data.length, out, eptr, function(err, success) {
     var terr = errors.decryption(eptr.deref());
@@ -320,7 +320,7 @@ ToxEncryptSave.prototype.decryptPassKey = function(data, passKey, callback) {
  * @return {Buffer} Decrypted data
  */
 ToxEncryptSave.prototype.decryptPassKeySync = function(data, passKey) {
-  var out = new Buffer(data.length - consts.TOX_PASS_ENCRYPTION_EXTRA_LENGTH),
+  var out = Buffer.alloc(data.length - consts.TOX_PASS_ENCRYPTION_EXTRA_LENGTH),
       eptr = ref.alloc(TOX_ERR_DECRYPTION),
       success = this.getLibrary().tox_pass_key_decrypt(passKey.ref(), data, data.length, out, eptr);
   var err = errors.decryption(eptr.deref());
@@ -403,7 +403,7 @@ ToxEncryptSave.prototype._performDerive = function(opts) {
       salt = opts['salt'], useSalt = opts['useSalt'],
       async = opts['async'], callback = opts['callback'];
 
-  if(_.isString(pass)) pass = new Buffer(pass);
+  if(_.isString(pass)) pass = Buffer.from(pass);
   var out = ref.alloc(ToxPassKey),
       eptr = ref.alloc(TOX_ERR_KEY_DERIVATION);
 

--- a/lib/toxencryptsave.js
+++ b/lib/toxencryptsave.js
@@ -16,12 +16,12 @@
  *
  */
 
-var ffi = require('ffi');
+var ffi = require('ffi-napi');
 var fs = require('fs');
 var path = require('path');
-var ref = require('ref');
-var RefArray = require('ref-array');
-var RefStruct = require('ref-struct');
+var ref = require('ref-napi');
+var RefArray = require('ref-array-napi');
+var RefStruct = require('ref-struct-napi');
 var _ = require('underscore');
 
 var consts = require(path.join(__dirname, 'consts'));

--- a/lib/toxoptions.js
+++ b/lib/toxoptions.js
@@ -16,8 +16,8 @@
  *
  */
 
-var ref = require('ref');
-var RefStruct = require('ref-struct');
+var ref = require('ref-napi');
+var RefStruct = require('ref-struct-napi');
 
 var CEnum = 'int32';
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -16,7 +16,7 @@
  *
  */
 
-require("buffer")
+require("buffer");
 var os = require("os");
 var _ = require("underscore");
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -17,8 +17,8 @@
  */
 
 require("buffer")
-var os = require('os');
-var _ = require('underscore');
+var os = require("os");
+var _ = require("underscore");
 
 /**
  * Convert a hex string to a Buffer. If not a string, will just
@@ -28,7 +28,7 @@ var _ = require('underscore');
  */
 var fromHex = function(hex) {
   if(_.isString(hex)) {
-    return (Buffer.from(hex, 'hex'));
+    return (Buffer.from(hex, "hex"));
   }
   return hex;
 };
@@ -55,15 +55,15 @@ var parseAddress = function(str) {
  */
 var parseProxy = function(str) {
   var type;
-  if(str.indexOf('http://') === 0) {
-    str = str.slice('http://'.length);
-    type = 'http';
-  } else if(str.indexOf('socks://') === 0) {
-    str = str.slice('socks://'.length);
-    type = 'socks';
-  } else if(str.indexOf('socks5://') === 0) {
-    str = str.slice('socks5://'.length);
-    type = 'socks';
+  if(str.indexOf("http://") === 0) {
+    str = str.slice("http://".length);
+    type = "http";
+  } else if(str.indexOf("socks://") === 0) {
+    str = str.slice("socks://".length);
+    type = "socks";
+  } else if(str.indexOf("socks5://") === 0) {
+    str = str.slice("socks5://".length);
+    type = "socks";
   }
 
   var proxy = parseAddress(str);
@@ -87,26 +87,26 @@ var size_t = function(value) {
     // @todo: Throw error
   }
 
-  var size = ref.alloc('size_t'),
+  var size = ref.alloc("size_t"),
       e = os.endianness();
 
   size.fill(0);
 
   // @todo: Fix for 64-bit integers?
   if(size.length === 8) {
-    if(e === 'BE') {
+    if(e === "BE") {
       size.writeUInt32BE(value, 4);
     } else {
       size.writeUInt32LE(value, 0);
     }
   } else if(size.length === 4) {
-    if(e === 'BE') {
+    if(e === "BE") {
       size.writeUInt32BE(value, 0);
     } else {
       size.writeUInt32LE(value, 0);
     }
   } else if (size.length === 2) {
-    if(e === 'BE') {
+    if(e === "BE") {
       size.writeUInt16BE(value, 0);
     } else {
       size.writeUInt16LE(value, 0);
@@ -131,7 +131,7 @@ var size_t = function(value) {
 var hexify = function(asyncFunc, callback) {
   asyncFunc(function(err, buffer) {
     if(callback) {
-      callback(err, buffer.toString('hex'));
+      callback(err, buffer.toString("hex"));
     }
   });
 };
@@ -143,7 +143,7 @@ var hexify = function(asyncFunc, callback) {
  */
 var hexifySync = function(syncFunction) {
   var addr = syncFunction();
-  return addr.toString('hex');
+  return addr.toString("hex");
 };
 
 /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -18,7 +18,6 @@
 
 require("buffer")
 var os = require('os');
-var ref = require('ref');
 var _ = require('underscore');
 
 /**
@@ -132,7 +131,7 @@ var size_t = function(value) {
 var hexify = function(asyncFunc, callback) {
   asyncFunc(function(err, buffer) {
     if(callback) {
-      callback(err, buffer.toHex().toString());
+      callback(err, buffer.toString('hex'));
     }
   });
 };
@@ -144,7 +143,7 @@ var hexify = function(asyncFunc, callback) {
  */
 var hexifySync = function(syncFunction) {
   var addr = syncFunction();
-  return addr.toHex().toString();
+  return addr.toString('hex');
 };
 
 /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -16,12 +16,10 @@
  *
  */
 
-var buffertools = require('buffertools');
+require("buffer")
 var os = require('os');
 var ref = require('ref');
 var _ = require('underscore');
-
-buffertools.extend();
 
 /**
  * Convert a hex string to a Buffer. If not a string, will just

--- a/lib/util.js
+++ b/lib/util.js
@@ -28,7 +28,7 @@ var _ = require('underscore');
  */
 var fromHex = function(hex) {
   if(_.isString(hex)) {
-    return (new Buffer(hex)).fromHex();
+    return (Buffer.from(hex, 'hex'));
   }
   return hex;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -386,23 +386,15 @@
       "dev": true
     },
     "ffi-napi": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/ffi-napi/-/ffi-napi-2.4.5.tgz",
-      "integrity": "sha512-24Et/c5/sRvZvpOZ9nvkK0Be1S8A1Vkt6aJSKGaohOGb5FwV4+EmecaTtNhN4TCLJDjYC8z/k4X8W1SC5IK/fw==",
+      "version": "git+https://github.com/node-ffi-napi/node-ffi-napi.git#40443ca8dad10cc3286c432774de3ce631d457e1",
+      "from": "git+https://github.com/node-ffi-napi/node-ffi-napi.git#40443ca8dad10cc3286c432774de3ce631d457e1",
       "requires": {
         "bindings": "^1.3.0",
         "debug": "^3.1.0",
         "get-uv-event-loop-napi-h": "^1.0.5",
-        "node-addon-api": "1.5.0",
+        "node-addon-api": "1.6.1",
         "ref-napi": "^1.4.0",
         "ref-struct-di": "^1.1.0"
-      },
-      "dependencies": {
-        "node-addon-api": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.5.0.tgz",
-          "integrity": "sha512-YsL/8dpBWxCFj3wAVAa/ceN4TlT8lACK8EgpuN0q/4ecflWHDuKpodb+tt7Rx22r/6FJ2f+IT25XSsXnZGwYgA=="
-        }
       }
     },
     "file-uri-to-path": {
@@ -457,14 +449,14 @@
       "dev": true
     },
     "get-symbol-from-current-process-h": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.1.tgz",
-      "integrity": "sha512-QvP1+tCDjgTiu+akjdEYd8eK8MFYy6nRCRNjfiCeQB9RJEHQZpN+WE+CVqPRNqjIVMwSqd0WiD008B+b7iIdaA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
+      "integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw=="
     },
     "get-uv-event-loop-napi-h": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.5.tgz",
-      "integrity": "sha512-uWDHId313vRTyqeLhlLWJS0CJOP8QXY5en/9Pv14dnPvAlRfKBfD6h2EDtoy7jxxOIWB9QgzYK16VCN3pCZOBg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
+      "integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
       "requires": {
         "get-symbol-from-current-process-h": "^1.0.1"
       }
@@ -1150,9 +1142,9 @@
       "dev": true
     },
     "node-addon-api": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
-      "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ=="
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.6.1.tgz",
+      "integrity": "sha512-GcLOYrG5/enbqH4SMsqXt6GQUQGGnDnE3FLDZzXYkCgQHuZV5UDFR+EboeY8kpG0avroyOjpFQ2qLEBosFcRIA=="
     },
     "nopt": {
       "version": "3.0.6",
@@ -1363,13 +1355,20 @@
       }
     },
     "ref-napi": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-1.4.2.tgz",
-      "integrity": "sha512-6AkdfqTLmP9oHQ6/aTnuIoPlVble6LHZ2wWqC1Sh/LWhnXHoT2L3CvyF72rJQ9w76XR5v9rIX6UQUwsry1vfBg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-1.4.3.tgz",
+      "integrity": "sha512-yE98eVwjpeGSbHjahn+hNlheGgKdV3gCW1rSj7HZL4ITzBhRb0HlUapWamRcAjZebPr3yuhvxeKFmso8NbRv5g==",
       "requires": {
         "bindings": "^1.3.0",
         "debug": "^3.1.0",
-        "node-addon-api": "^1.6.2"
+        "node-addon-api": "^2.0.0"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.0.tgz",
+          "integrity": "sha512-ASCL5U13as7HhOExbT6OlWJJUV/lLzL2voOSP1UVehpRD8FbSrSDjfScK/KwAvVTI5AS6r4VwbOMlIqtvRidnA=="
+        }
       }
     },
     "ref-struct-di": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/parser": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
+      "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -22,7 +28,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.2"
+        "color-convert": "^1.9.0"
       }
     },
     "argparse": {
@@ -31,7 +37,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       },
       "dependencies": {
         "sprintf-js": {
@@ -53,8 +59,23 @@
       "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
       "integrity": "sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k=",
       "requires": {
-        "debug": "2.6.9",
-        "es6-symbol": "3.1.1"
+        "debug": "^2.2.0",
+        "es6-symbol": "^3.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "array-uniq": {
@@ -64,19 +85,13 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.17.14"
       }
-    },
-    "babylon": {
-      "version": "7.0.0-beta.19",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
-      "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
-      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -85,14 +100,17 @@
       "dev": true
     },
     "bindings": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
       "dev": true
     },
     "brace-expansion": {
@@ -101,7 +119,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -109,12 +127,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
-      "dev": true
-    },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "camelcase": {
@@ -129,28 +141,28 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       }
     },
     "catharsis": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
-      "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
+      "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
       "dev": true,
       "requires": {
-        "underscore-contrib": "0.3.0"
+        "lodash": "^4.17.14"
       }
     },
     "chalk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.4.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "coffeescript": {
@@ -160,18 +172,18 @@
       "dev": true
     },
     "color-convert": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
-      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "colors": {
@@ -186,7 +198,7 @@
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true,
       "requires": {
-        "graceful-readlink": "1.0.1"
+        "graceful-readlink": ">= 1.0.0"
       }
     },
     "concat-map": {
@@ -195,20 +207,17 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
-    },
     "cross-spawn": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-      "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.3",
-        "which": "1.3.1"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "currently-unhandled": {
@@ -217,15 +226,16 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "d": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
       "requires": {
-        "es5-ext": "0.10.45"
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
       }
     },
     "dateformat": {
@@ -234,16 +244,16 @@
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1",
-        "meow": "3.7.0"
+        "get-stdin": "^4.0.1",
+        "meow": "^3.3.0"
       }
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "decamelize": {
@@ -259,27 +269,33 @@
       "dev": true
     },
     "dom-serializer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz",
+      "integrity": "sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==",
       "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
       },
       "dependencies": {
         "domelementtype": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+          "dev": true
+        },
+        "entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
           "dev": true
         }
       }
     },
     "domelementtype": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
       "dev": true
     },
     "domhandler": {
@@ -288,7 +304,7 @@
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -297,14 +313,14 @@
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "dev": true,
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "entities": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
       "dev": true
     },
     "error-ex": {
@@ -313,17 +329,17 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es5-ext": {
-      "version": "0.10.45",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
-      "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
+      "version": "0.10.51",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.51.tgz",
+      "integrity": "sha512-oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==",
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1",
-        "next-tick": "1.0.0"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "^1.0.0"
       }
     },
     "es6-iterator": {
@@ -331,18 +347,18 @@
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.45",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-symbol": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.2.tgz",
+      "integrity": "sha512-/ZypxQsArlv+KHpGvng52/Iz8by3EQPxhmbuz8yFG89N/caTFBSbcXONDw0aMjy827gQg26XAjP4uXFvnfINmQ==",
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.45"
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.51"
       }
     },
     "escape-string-regexp": {
@@ -352,9 +368,9 @@
       "dev": true
     },
     "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "eventemitter2": {
@@ -369,17 +385,30 @@
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
-    "ffi": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ffi/-/ffi-2.2.0.tgz",
-      "integrity": "sha1-vxiwRmain3EiftVoldVDCvRwQvo=",
+    "ffi-napi": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/ffi-napi/-/ffi-napi-2.4.5.tgz",
+      "integrity": "sha512-24Et/c5/sRvZvpOZ9nvkK0Be1S8A1Vkt6aJSKGaohOGb5FwV4+EmecaTtNhN4TCLJDjYC8z/k4X8W1SC5IK/fw==",
       "requires": {
-        "bindings": "1.2.1",
-        "debug": "2.6.9",
-        "nan": "2.10.0",
-        "ref": "1.3.5",
-        "ref-struct": "1.1.0"
+        "bindings": "^1.3.0",
+        "debug": "^3.1.0",
+        "get-uv-event-loop-napi-h": "^1.0.5",
+        "node-addon-api": "1.5.0",
+        "ref-napi": "^1.4.0",
+        "ref-struct-di": "^1.1.0"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.5.0.tgz",
+          "integrity": "sha512-YsL/8dpBWxCFj3wAVAa/ceN4TlT8lACK8EgpuN0q/4ecflWHDuKpodb+tt7Rx22r/6FJ2f+IT25XSsXnZGwYgA=="
+        }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "find-up": {
       "version": "1.1.2",
@@ -387,8 +416,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "findup-sync": {
@@ -397,7 +426,7 @@
       "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
       "dev": true,
       "requires": {
-        "glob": "5.0.15"
+        "glob": "~5.0.0"
       },
       "dependencies": {
         "glob": {
@@ -406,11 +435,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -427,6 +456,19 @@
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
       "dev": true
     },
+    "get-symbol-from-current-process-h": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.1.tgz",
+      "integrity": "sha512-QvP1+tCDjgTiu+akjdEYd8eK8MFYy6nRCRNjfiCeQB9RJEHQZpN+WE+CVqPRNqjIVMwSqd0WiD008B+b7iIdaA=="
+    },
+    "get-uv-event-loop-napi-h": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.5.tgz",
+      "integrity": "sha512-uWDHId313vRTyqeLhlLWJS0CJOP8QXY5en/9Pv14dnPvAlRfKBfD6h2EDtoy7jxxOIWB9QgzYK16VCN3pCZOBg==",
+      "requires": {
+        "get-symbol-from-current-process-h": "^1.0.1"
+      }
+    },
     "getobject": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
@@ -439,18 +481,18 @@
       "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
     },
     "graceful-readlink": {
@@ -466,28 +508,28 @@
       "dev": true
     },
     "grunt": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.3.tgz",
-      "integrity": "sha512-/JzmZNPfKorlCrrmxWqQO4JVodO+DVd5XX4DkocL/1WlLlKVLE9+SdEIempOAxDhWPysLle6afvn/hg7Ck2k9g==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.4.tgz",
+      "integrity": "sha512-PYsMOrOC+MsdGEkFVwMaMyc6Ob7pKmq+deg1Sjr+vvMWp35sztfwKE7qoN51V+UEtHsyNuMcGdgMLFkBHvMxHQ==",
       "dev": true,
       "requires": {
-        "coffeescript": "1.10.0",
-        "dateformat": "1.0.12",
-        "eventemitter2": "0.4.14",
-        "exit": "0.1.2",
-        "findup-sync": "0.3.0",
-        "glob": "7.0.6",
-        "grunt-cli": "1.2.0",
-        "grunt-known-options": "1.1.0",
-        "grunt-legacy-log": "2.0.0",
-        "grunt-legacy-util": "1.1.1",
-        "iconv-lite": "0.4.23",
-        "js-yaml": "3.5.5",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.2"
+        "coffeescript": "~1.10.0",
+        "dateformat": "~1.0.12",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.3.0",
+        "glob": "~7.0.0",
+        "grunt-cli": "~1.2.0",
+        "grunt-known-options": "~1.1.0",
+        "grunt-legacy-log": "~2.0.0",
+        "grunt-legacy-util": "~1.1.1",
+        "iconv-lite": "~0.4.13",
+        "js-yaml": "~3.13.0",
+        "minimatch": "~3.0.2",
+        "mkdirp": "~0.5.1",
+        "nopt": "~3.0.6",
+        "path-is-absolute": "~1.0.0",
+        "rimraf": "~2.6.2"
       },
       "dependencies": {
         "grunt-cli": {
@@ -496,29 +538,34 @@
           "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
           "dev": true,
           "requires": {
-            "findup-sync": "0.3.0",
-            "grunt-known-options": "1.1.0",
-            "nopt": "3.0.6",
-            "resolve": "1.1.7"
+            "findup-sync": "~0.3.0",
+            "grunt-known-options": "~1.1.0",
+            "nopt": "~3.0.6",
+            "resolve": "~1.1.0"
           }
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
         }
       }
     },
     "grunt-jsdoc": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/grunt-jsdoc/-/grunt-jsdoc-2.2.1.tgz",
-      "integrity": "sha512-33QZYBYjv2Ph3H2ygqXHn/o0ttfptw1f9QciOTgvzhzUeiPrnvzMNUApTPtw22T6zgReE5FZ1RR58U2wnK/l+w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/grunt-jsdoc/-/grunt-jsdoc-2.4.0.tgz",
+      "integrity": "sha512-JpZd1W7HbK0sHbpiL9+VyDFwZlkYoDQMaP+v6z1R23W/NYLoqJM76L9eBOr7O6NycqtddRHN5DzlSkW45MJ82w==",
       "dev": true,
       "requires": {
-        "cross-spawn": "3.0.1",
-        "jsdoc": "3.5.5",
-        "marked": "0.3.19"
+        "cross-spawn": "^6.0.5",
+        "jsdoc": "~3.6.0"
       }
     },
     "grunt-known-options": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz",
-      "integrity": "sha1-pCdO6zL6dl2lp6OxcSYXzjsUQUk=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.1.tgz",
+      "integrity": "sha512-cHwsLqoighpu7TuYj5RonnEuxGVFnztcUqTqp5rXFGYL4OuPFofwC4Ycg7n9fYwvK6F5WbYgeVOwph9Crs2fsQ==",
       "dev": true
     },
     "grunt-legacy-log": {
@@ -527,10 +574,10 @@
       "integrity": "sha512-1m3+5QvDYfR1ltr8hjiaiNjddxGdQWcH0rw1iKKiQnF0+xtgTazirSTGu68RchPyh1OBng1bBUjLmX8q9NpoCw==",
       "dev": true,
       "requires": {
-        "colors": "1.1.2",
-        "grunt-legacy-log-utils": "2.0.1",
-        "hooker": "0.2.3",
-        "lodash": "4.17.10"
+        "colors": "~1.1.2",
+        "grunt-legacy-log-utils": "~2.0.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.17.5"
       }
     },
     "grunt-legacy-log-utils": {
@@ -539,8 +586,8 @@
       "integrity": "sha512-o7uHyO/J+i2tXG8r2bZNlVk20vlIFJ9IEYyHMCQGfWYru8Jv3wTqKZzvV30YW9rWEjq0eP3cflQ1qWojIe9VFA==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "lodash": "4.17.10"
+        "chalk": "~2.4.1",
+        "lodash": "~4.17.10"
       }
     },
     "grunt-legacy-util": {
@@ -549,13 +596,13 @@
       "integrity": "sha512-9zyA29w/fBe6BIfjGENndwoe1Uy31BIXxTH3s8mga0Z5Bz2Sp4UCjkeyv2tI449ymkx3x26B+46FV4fXEddl5A==",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "exit": "0.1.2",
-        "getobject": "0.1.0",
-        "hooker": "0.2.3",
-        "lodash": "4.17.10",
-        "underscore.string": "3.3.4",
-        "which": "1.3.1"
+        "async": "~1.5.2",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.17.10",
+        "underscore.string": "~3.3.4",
+        "which": "~1.3.0"
       },
       "dependencies": {
         "async": {
@@ -572,8 +619,8 @@
       "integrity": "sha1-Q595FZ7RHmSmUaacyKPQK+v17MI=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "npm-run-path": "2.0.2"
+        "chalk": "^1.0.0",
+        "npm-run-path": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -588,11 +635,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -609,7 +656,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -631,32 +678,32 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
       "dev": true
     },
     "htmlparser2": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.4.2",
-        "domutils": "1.7.0",
-        "entities": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
       }
     },
     "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "indent-string": {
@@ -665,7 +712,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "inflight": {
@@ -674,14 +721,14 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
     "ink-docstrap": {
@@ -690,8 +737,8 @@
       "integrity": "sha512-STx5orGQU1gfrkoI/fMU7lX6CSP7LBGO10gXNgOZhwKhUqbtNjCkYSewJtNnLmWP1tAGN6oyEpG1HFPw5vpa5Q==",
       "dev": true,
       "requires": {
-        "moment": "2.22.2",
-        "sanitize-html": "1.18.2"
+        "moment": "^2.14.1",
+        "sanitize-html": "^1.13.0"
       }
     },
     "is-arrayish": {
@@ -700,34 +747,19 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "1.1.1"
-      }
-    },
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
@@ -737,48 +769,50 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
-      "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "2.7.3"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "js2xmlparser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
-      "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.0.tgz",
+      "integrity": "sha512-WuNgdZOXVmBk5kUPMcTcVUpbGRzLfNkv7+7APq7WiDihpXVKrgxo6wwRpRl9OQeEBgKCVk9mR7RbzrnNWC8oBw==",
       "dev": true,
       "requires": {
-        "xmlcreate": "1.0.2"
+        "xmlcreate": "^2.0.0"
       }
     },
     "jsdoc": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
-      "integrity": "sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.3.tgz",
+      "integrity": "sha512-Yf1ZKA3r9nvtMWHO1kEuMZTlHOF8uoQ0vyo5eH7SQy5YeIiHM+B0DgKnn+X6y6KDYZcF7G2SPkKF+JORCXWE/A==",
       "dev": true,
       "requires": {
-        "babylon": "7.0.0-beta.19",
-        "bluebird": "3.5.1",
-        "catharsis": "0.8.9",
-        "escape-string-regexp": "1.0.5",
-        "js2xmlparser": "3.0.0",
-        "klaw": "2.0.0",
-        "marked": "0.3.19",
-        "mkdirp": "0.5.1",
-        "requizzle": "0.2.1",
-        "strip-json-comments": "2.0.1",
+        "@babel/parser": "^7.4.4",
+        "bluebird": "^3.5.4",
+        "catharsis": "^0.8.11",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.0",
+        "klaw": "^3.0.0",
+        "markdown-it": "^8.4.2",
+        "markdown-it-anchor": "^5.0.2",
+        "marked": "^0.7.0",
+        "mkdirp": "^0.5.1",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.0.1",
         "taffydb": "2.6.2",
-        "underscore": "1.8.3"
+        "underscore": "~1.9.1"
       },
       "dependencies": {
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
           "dev": true
         }
       }
@@ -790,12 +824,21 @@
       "dev": true
     },
     "klaw": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
-      "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
+      }
+    },
+    "linkify-it": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "dev": true,
+      "requires": {
+        "uc.micro": "^1.0.1"
       }
     },
     "load-json-file": {
@@ -804,17 +847,17 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash._baseassign": {
@@ -823,8 +866,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -863,9 +906,9 @@
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
     },
     "lodash.escaperegexp": {
@@ -904,15 +947,15 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.mergewith": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true
     },
     "loud-rejection": {
@@ -921,18 +964,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
-      }
-    },
-    "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-      "dev": true,
-      "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "map-obj": {
@@ -941,10 +974,35 @@
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
+    "markdown-it": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
+      "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "entities": "~1.1.1",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      }
+    },
+    "markdown-it-anchor": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.5.tgz",
+      "integrity": "sha512-xLIjLQmtym3QpoY9llBgApknl7pxAcN3WDRc2d3rwpl+/YvDZHPmKscGs+L6E05xf2KrCXPBvosWt7MZukwSpQ==",
+      "dev": true
+    },
     "marked": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
+      "dev": true
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
       "dev": true
     },
     "meow": {
@@ -953,16 +1011,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       }
     },
     "minimatch": {
@@ -971,7 +1029,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1038,12 +1096,12 @@
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-flag": {
@@ -1052,37 +1110,49 @@
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
         "supports-color": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
     },
     "moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
       "dev": true
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node-addon-api": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
+      "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ=="
     },
     "nopt": {
       "version": "3.0.6",
@@ -1090,19 +1160,19 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.1"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.6.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.3"
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "npm-run-path": {
@@ -1111,7 +1181,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "number-is-nan": {
@@ -1132,7 +1202,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "parse-json": {
@@ -1141,7 +1211,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.2"
+        "error-ex": "^1.2.0"
       }
     },
     "path-exists": {
@@ -1150,7 +1220,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -1165,15 +1235,21 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "pify": {
@@ -1194,31 +1270,30 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "postcss": {
-      "version": "6.0.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-      "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+      "version": "7.0.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+      "integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "source-map": "0.6.1",
-        "supports-color": "5.4.0"
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
-    },
-    "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "dev": true
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
     },
     "read-pkg": {
       "version": "1.1.0",
@@ -1226,9 +1301,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -1237,23 +1312,19 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+      "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "redent": {
@@ -1262,37 +1333,75 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
-    "ref": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ref/-/ref-1.3.5.tgz",
-      "integrity": "sha512-2cBCniTtxcGUjDpvFfVpw323a83/0RLSGJJY5l5lcomZWhYpU2cuLdsvYqMixvsdLJ9+sTdzEkju8J8ZHDM2nA==",
-      "requires": {
-        "bindings": "1.2.1",
-        "debug": "2.6.9",
-        "nan": "2.10.0"
-      }
-    },
-    "ref-array": {
+    "ref-array-napi": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ref-array/-/ref-array-1.2.0.tgz",
-      "integrity": "sha1-u6hwFS1O4KvtFCGwYjkvCwGEKQw=",
+      "resolved": "https://registry.npmjs.org/ref-array-napi/-/ref-array-napi-1.2.0.tgz",
+      "integrity": "sha512-EkqS2iyJsrPAGu4Cv5bGAItuDEsE9ZXPoICU0dYB7qqLgksIhmMS4HaBRyJVsrTwb6Da/PNAZgBy6T6gN/HbkQ==",
       "requires": {
-        "array-index": "1.0.0",
-        "debug": "2.6.9",
-        "ref": "1.3.5"
+        "array-index": "1",
+        "debug": "2",
+        "ref-napi": "^1.4.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
-    "ref-struct": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ref-struct/-/ref-struct-1.1.0.tgz",
-      "integrity": "sha1-XV7mWtQc78Olxf60BYcmHkee3BM=",
+    "ref-napi": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-1.4.2.tgz",
+      "integrity": "sha512-6AkdfqTLmP9oHQ6/aTnuIoPlVble6LHZ2wWqC1Sh/LWhnXHoT2L3CvyF72rJQ9w76XR5v9rIX6UQUwsry1vfBg==",
       "requires": {
-        "debug": "2.6.9",
-        "ref": "1.3.5"
+        "bindings": "^1.3.0",
+        "debug": "^3.1.0",
+        "node-addon-api": "^1.6.2"
+      }
+    },
+    "ref-struct-di": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.0.tgz",
+      "integrity": "sha512-gghZITj/iQwdwFDduZ6T8kL2B2ogInlOz7AOB0ggFoEc7akAKMcDrbzh3OIPk13Kxy8U2bHPvN6nejcBh4jN7A==",
+      "requires": {
+        "debug": "^3.1.0"
+      }
+    },
+    "ref-struct-napi": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ref-struct-napi/-/ref-struct-napi-1.1.0.tgz",
+      "integrity": "sha512-9GwNq6PwVKhe8ZX4E51+3knUMJfyQumT9RCsXHBRDPfSYbOfK34TbQlEyvfuPOsb0xOlqzkR3CkTmD8gIdmtgQ==",
+      "requires": {
+        "debug": "2",
+        "ref-napi": "^1.4.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "repeating": {
@@ -1301,45 +1410,56 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "requizzle": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
-      "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
+      "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
       "dev": true,
       "requires": {
-        "underscore": "1.6.0"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-          "dev": true
-        }
+        "lodash": "^4.17.14"
       }
     },
     "resolve": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-      "dev": true
-    },
-    "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
       "dev": true,
       "requires": {
-        "glob": "7.0.6"
+        "path-parse": "^1.0.6"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.5",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+          "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
       "dev": true
     },
     "safer-buffer": {
@@ -1349,40 +1469,55 @@
       "dev": true
     },
     "sanitize-html": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.18.2.tgz",
-      "integrity": "sha512-52ThA+Z7h6BnvpSVbURwChl10XZrps5q7ytjTwWcIe9bmJwnVP6cpEVK2NvDOUhGupoqAvNbUz3cpnJDp4+/pg==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.20.1.tgz",
+      "integrity": "sha512-txnH8TQjaQvg2Q0HY06G6CDJLVYCpbnxrdO0WN8gjCKaU5J0KbyGYhZxx5QJg3WLZ1lB7XU9kDkfrCXUozqptA==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "htmlparser2": "3.9.2",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.escaperegexp": "4.1.2",
-        "lodash.isplainobject": "4.0.6",
-        "lodash.isstring": "4.0.1",
-        "lodash.mergewith": "4.6.1",
-        "postcss": "6.0.23",
-        "srcset": "1.0.0",
-        "xtend": "4.0.1"
+        "chalk": "^2.4.1",
+        "htmlparser2": "^3.10.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.mergewith": "^4.6.1",
+        "postcss": "^7.0.5",
+        "srcset": "^1.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
     "should": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/should/-/should-13.2.1.tgz",
-      "integrity": "sha512-l+/NwEMO+DcstsHEwPHRHzC9j4UOE3VQwJGcMWSsD/vqpqHbnQ+1iSHy64Ihmmjx1uiRPD9pFadTSc3MJtXAgw==",
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
       "dev": true,
       "requires": {
-        "should-equal": "2.0.0",
-        "should-format": "3.0.3",
-        "should-type": "1.4.0",
-        "should-type-adaptors": "1.1.0",
-        "should-util": "1.0.0"
+        "should-equal": "^2.0.0",
+        "should-format": "^3.0.3",
+        "should-type": "^1.4.0",
+        "should-type-adaptors": "^1.0.1",
+        "should-util": "^1.0.0"
       }
     },
     "should-equal": {
@@ -1391,7 +1526,7 @@
       "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
       "dev": true,
       "requires": {
-        "should-type": "1.4.0"
+        "should-type": "^1.4.0"
       }
     },
     "should-format": {
@@ -1400,8 +1535,8 @@
       "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
       "dev": true,
       "requires": {
-        "should-type": "1.4.0",
-        "should-type-adaptors": "1.1.0"
+        "should-type": "^1.3.0",
+        "should-type-adaptors": "^1.0.1"
       }
     },
     "should-type": {
@@ -1416,14 +1551,14 @@
       "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
       "dev": true,
       "requires": {
-        "should-type": "1.4.0",
-        "should-util": "1.0.0"
+        "should-type": "^1.3.0",
+        "should-util": "^1.0.0"
       }
     },
     "should-util": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
-      "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+      "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
       "dev": true
     },
     "signal-exit": {
@@ -1439,19 +1574,19 @@
       "dev": true
     },
     "spdx-correct": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
       "dev": true
     },
     "spdx-expression-parse": {
@@ -1460,20 +1595,20 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
     "sprintf-js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
       "dev": true
     },
     "srcset": {
@@ -1482,17 +1617,17 @@
       "integrity": "sha1-pWad4StC87HV6D7QPHEEb8SPQe8=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3",
-        "number-is-nan": "1.0.1"
+        "array-uniq": "^1.0.2",
+        "number-is-nan": "^1.0.0"
       }
     },
     "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.2.0"
       }
     },
     "strip-ansi": {
@@ -1501,7 +1636,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -1510,7 +1645,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-indent": {
@@ -1519,22 +1654,22 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
       "dev": true
     },
     "supports-color": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "taffydb": {
@@ -1549,36 +1684,30 @@
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
     },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
+    },
     "underscore": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
       "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
     },
-    "underscore-contrib": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
-      "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
-      "dev": true,
-      "requires": {
-        "underscore": "1.6.0"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-          "dev": true
-        }
-      }
-    },
     "underscore.string": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
-      "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
+      "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "sprintf-js": "^1.0.3",
+        "util-deprecate": "^1.0.2"
       }
     },
     "util-deprecate": {
@@ -1588,13 +1717,13 @@
       "dev": true
     },
     "validate-npm-package-license": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.0.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "which": {
@@ -1603,7 +1732,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "wrappy": {
@@ -1613,21 +1742,15 @@
       "dev": true
     },
     "xmlcreate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
-      "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.1.tgz",
+      "integrity": "sha512-MjGsXhKG8YjTKrDCXseFo3ClbMGvUD4en29H2Cev1dv4P/chlpw6KdYmlCWDkhosBVKRDjM836+3e3pm1cBNJA==",
       "dev": true
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,11 +111,6 @@
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
-    "buffertools": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/buffertools/-/buffertools-2.1.6.tgz",
-      "integrity": "sha1-MMGbCFY2uI32kq7v7qD/FWeA6RY="
-    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "test": "mocha"
   },
   "dependencies": {
-    "ffi-napi": "^2.2.0",
+    "ffi-napi": "git+https://github.com/node-ffi-napi/node-ffi-napi.git#40443ca8dad10cc3286c432774de3ce631d457e1",
     "ref-array-napi": "^1.2.0",
-    "ref-napi": "^1.4.2",
+    "ref-napi": "^1.4.3",
     "ref-struct-napi": "^1.1.0",
     "underscore": "^1.8.3"
   },

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "test": "mocha"
   },
   "dependencies": {
-    "ffi": "^2.2.0",
-    "ref": "^1.3.5",
-    "ref-array": "^1.2.0",
-    "ref-struct": "^1.1.0",
+    "ffi-napi": "^2.2.0",
+    "ref-array-napi": "^1.2.0",
+    "ref-napi": "^1.4.2",
+    "ref-struct-napi": "^1.1.0",
     "underscore": "^1.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "test": "mocha"
   },
   "dependencies": {
-    "buffertools": "^2.1.6",
     "ffi": "^2.2.0",
     "ref": "^1.3.5",
     "ref-array": "^1.2.0",

--- a/test/tox.js
+++ b/test/tox.js
@@ -164,7 +164,7 @@ describe('Tox', function() {
         added.should.equal(retrieved);
 
         var retrievedKey = tox.getFriendPublicKeySync(added);
-        retrievedKey.toHex().toLowerCase().should.equal(publicKey.toLowerCase());
+        retrievedKey.toString('hex').toLowerCase().should.equal(publicKey.toLowerCase());
 
         tox.hasFriendSync(added).should.be.true;
       });
@@ -185,7 +185,7 @@ describe('Tox', function() {
               added.should.equal(retrieved);
               tox.getFriendPublicKey(added, function(err, retrievedKey) {
                 if(err) { done(err); return; }
-                retrievedKey.toHex().toLowerCase().should.equal(publicKey.toLowerCase());
+                retrievedKey.toString('hex').toLowerCase().should.equal(publicKey.toLowerCase());
                 tox.hasFriend(added, function(err, exists) {
                   exists.should.be.true;
                   done(err);
@@ -657,12 +657,12 @@ describe('Tox', function() {
 
   describe('hashing', function() {
     it('should hash some data', function() {
-      var hash = tox.hashSync(new Buffer([0, 1, 2, 3]));
+      var hash = tox.hashSync(Buffer.from([0, 1, 2, 3]));
       hash.length.should.equal(consts.TOX_HASH_LENGTH);
     });
 
     it('should hash some data (async)', function(done) {
-      tox.hash(new Buffer([0, 1, 2, 3]), function(err, hash) {
+      tox.hash(Buffer.from([0, 1, 2, 3]), function(err, hash) {
         if(!err) {
           hash.length.should.equal(consts.TOX_HASH_LENGTH);
           done();

--- a/test/tox.js
+++ b/test/tox.js
@@ -18,7 +18,6 @@
 
 var assert = require('assert');
 var async = require('async');
-var buffertools = require('buffertools');
 var fs = require('fs');
 var mktemp = require('mktemp');
 var should = require('should');
@@ -36,7 +35,7 @@ var Tox = loadModule('tox');
 var ToxEncryptSave = loadModule('toxencryptsave');
 var consts = loadModule('consts');
 
-buffertools.extend();
+require("buffer")
 
 // Helper mktemp functions
 var mktempToxSync = mktemp.createFileSync.bind(undefined, 'XXXXX.tox');

--- a/test/tox.js
+++ b/test/tox.js
@@ -16,32 +16,32 @@
  *
  */
 
-var assert = require('assert');
-var async = require('async');
-var fs = require('fs');
-var mktemp = require('mktemp');
-var should = require('should');
-var path = require('path');
+var assert = require("assert");
+var async = require("async");
+var fs = require("fs");
+var mktemp = require("mktemp");
+var should = require("should");
+var path = require("path");
 
 function loadModule(mod) {
   try {
-    return require(path.join('js-toxcore-c', 'js-toxcore-c', 'js-toxcore-c', 'lib', mod));
+    return require(path.join("js-toxcore-c", "js-toxcore-c", "js-toxcore-c", "lib", mod));
   } catch (e) {
-    return require(path.join(__dirname, '..', 'lib', mod));
+    return require(path.join(__dirname, "..", "lib", mod));
   }
 }
 
-var Tox = loadModule('tox');
-var ToxEncryptSave = loadModule('toxencryptsave');
-var consts = loadModule('consts');
+var Tox = loadModule("tox");
+var ToxEncryptSave = loadModule("toxencryptsave");
+var consts = loadModule("consts");
 
-require("buffer")
+require("buffer");
 
 // Helper mktemp functions
-var mktempToxSync = mktemp.createFileSync.bind(undefined, 'XXXXX.tox');
+var mktempToxSync = mktemp.createFileSync.bind(undefined, "XXXXX.tox");
 
 // @todo: Cleanup (kill tox instances afterwards)
-describe('Tox', function() {
+describe("Tox", function() {
   var tox = new Tox();
   tox.start();
 
@@ -58,25 +58,25 @@ describe('Tox', function() {
   var addressRegex = /^[0-9a-fA-F]{76}$/;
 
   var fakeAddresses = [
-    '7bd26c7867ef3a08f0010dc646845284a52f69cb9fded8a2635da3bfe0ba7a4f8facd97f24d6',
-    '18e8bba90991e22dc70d8e8c188c93c4d38d62d2ab4c6d5aa6758b9b34925a31b18e0e25019b'
+    "7bd26c7867ef3a08f0010dc646845284a52f69cb9fded8a2635da3bfe0ba7a4f8facd97f24d6",
+    "18e8bba90991e22dc70d8e8c188c93c4d38d62d2ab4c6d5aa6758b9b34925a31b18e0e25019b"
   ];
 
   var fakePublicKeys = [
-    '94f44a6edbfc8ff1dc3ed3c460da046f4280a234edcbd7f11c023e43f4f0cd67',
-    '5a1cd1a18f4411de8267154b6d9ac3a93d98e8c6e682987803cc6057472c444c',
-    'fd31376ac876b7a5199239e859ec001a518dc79e9fb5c486b5dde3f3fd97c052',
-    '32ab7ac2c01b0413804f2de691abafd1420f4bb41a1cdcaafbb4650b3b13a41a'
+    "94f44a6edbfc8ff1dc3ed3c460da046f4280a234edcbd7f11c023e43f4f0cd67",
+    "5a1cd1a18f4411de8267154b6d9ac3a93d98e8c6e682987803cc6057472c444c",
+    "fd31376ac876b7a5199239e859ec001a518dc79e9fb5c486b5dde3f3fd97c052",
+    "32ab7ac2c01b0413804f2de691abafd1420f4bb41a1cdcaafbb4650b3b13a41a"
   ];
 
-  describe('#getAddress(), #getAddressSync()', function() {
-    it('should return a buffer of expected size', function() {
+  describe("#getAddress(), #getAddressSync()", function() {
+    it("should return a buffer of expected size", function() {
       var addr = tox.getAddressSync();
       addr.should.be.a.Buffer;
       addr.length.should.equal(consts.TOX_FRIEND_ADDRESS_SIZE);
     });
 
-    it('should return a buffer of expected size (async)', function(done) {
+    it("should return a buffer of expected size (async)", function(done) {
       tox.getAddress(function(err, addr) {
         addr.should.be.a.Buffer;
         addr.length.should.equal(consts.TOX_FRIEND_ADDRESS_SIZE);
@@ -85,13 +85,13 @@ describe('Tox', function() {
     });
   });
 
-  describe('#getAddressHex(), #getAddressHexSync()', function() {
-    it('should return an address as a hex string', function() {
+  describe("#getAddressHex(), #getAddressHexSync()", function() {
+    it("should return an address as a hex string", function() {
       var addr = tox.getAddressHexSync();
       addr.should.match(addressRegex);
     });
 
-    it('should return an address as a hex string (async)', function(done) {
+    it("should return an address as a hex string (async)", function(done) {
       tox.getAddressHex(function(err, addr) {
         addr.should.match(addressRegex);
         done(err);
@@ -99,14 +99,14 @@ describe('Tox', function() {
     });
   });
 
-  describe('friend getter functions', function() {
-    describe('before setting', function() {
-      describe('#getFriendByPublicKey(), #getFriendByPublicKeySync()', function() {
-        it('should throw an exception', function() {
+  describe("friend getter functions", function() {
+    describe("before setting", function() {
+      describe("#getFriendByPublicKey(), #getFriendByPublicKeySync()", function() {
+        it("should throw an exception", function() {
           (function() { tox.getFriendByPublicKeySync(fakePublicKeys[0]); }).should.throw();
         });
 
-        it('should return an exception (async)', function(done) {
+        it("should return an exception (async)", function(done) {
           tox.getFriendByPublicKey(fakePublicKeys[0], function(err) {
             should.exist(err);
             done();
@@ -114,12 +114,12 @@ describe('Tox', function() {
         });
       });
 
-      describe('#getFriendPublicKey(), #getFriendPublicKeySync()', function() {
-        it('should throw an exception', function() {
+      describe("#getFriendPublicKey(), #getFriendPublicKeySync()", function() {
+        it("should throw an exception", function() {
           (function() { tox.getFriendPublicKeySync(0); }).should.throw();
         });
 
-        it('should return an exception (async)', function(done) {
+        it("should return an exception (async)", function(done) {
           tox.getFriendPublicKey(0, function(err) {
             should.exist(err);
             done();
@@ -127,12 +127,12 @@ describe('Tox', function() {
         });
       });
 
-      describe('#deleteFriend(), #deleteFriendSync()', function() {
-        it('should throw an exception if friend doesn\'t exist', function() {
+      describe("#deleteFriend(), #deleteFriendSync()", function() {
+        it("should throw an exception if friend doesn\"t exist", function() {
           (function() { tox.deleteFriendSync(0); }).should.throw();
         });
 
-        it('should return an exception if friend doesn\'t exist', function(done) {
+        it("should return an exception if friend doesn\"t exist", function(done) {
           tox.deleteFriend(0, function(err) {
             should.exist(err);
             done();
@@ -140,12 +140,12 @@ describe('Tox', function() {
         });
       });
 
-      describe('#hasFriend(), #hasFriendSync()', function() {
-        it('should return false if friend doesn\'t exist', function() {
+      describe("#hasFriend(), #hasFriendSync()", function() {
+        it("should return false if friend doesn\"t exist", function() {
           tox.hasFriendSync(0).should.be.false;
         });
 
-        it('should return false if friend doesn\'t exist (async)', function(done) {
+        it("should return false if friend doesn\"t exist (async)", function(done) {
           tox.hasFriend(0, function(err, exists) {
             exists.should.be.false;
             done(err);
@@ -154,8 +154,8 @@ describe('Tox', function() {
       });
     });
 
-    describe('#getFriendPublicKey(), #getFriendPublicKeySync()', function() {
-      it('should return a number if a friend has the public key', function() {
+    describe("#getFriendPublicKey(), #getFriendPublicKeySync()", function() {
+      it("should return a number if a friend has the public key", function() {
         var publicKey = fakePublicKeys[2];
         (function() { tox.getFriendByPublicKeySync(publicKey) }).should.throw();
         // Add and try again
@@ -164,17 +164,17 @@ describe('Tox', function() {
         added.should.equal(retrieved);
 
         var retrievedKey = tox.getFriendPublicKeySync(added);
-        retrievedKey.toString('hex').toLowerCase().should.equal(publicKey.toLowerCase());
+        retrievedKey.toString("hex").toLowerCase().should.equal(publicKey.toLowerCase());
 
         tox.hasFriendSync(added).should.be.true;
       });
 
-      it('last online for never-seen friend should be a NaN Date', function() {
+      it("last online for never-seen friend should be a NaN Date", function() {
         var lastOnline = tox.getFriendLastOnlineSync(0);
         lastOnline.getTime().should.be.NaN;
       });
 
-      it('should return a number if a friend has the public key (async)', function(done) {
+      it("should return a number if a friend has the public key (async)", function(done) {
         var publicKey = fakePublicKeys[3];
         tox.getFriendByPublicKey(publicKey, function(err) {
           should.exist(err);
@@ -185,7 +185,7 @@ describe('Tox', function() {
               added.should.equal(retrieved);
               tox.getFriendPublicKey(added, function(err, retrievedKey) {
                 if(err) { done(err); return; }
-                retrievedKey.toString('hex').toLowerCase().should.equal(publicKey.toLowerCase());
+                retrievedKey.toString("hex").toLowerCase().should.equal(publicKey.toLowerCase());
                 tox.hasFriend(added, function(err, exists) {
                   exists.should.be.true;
                   done(err);
@@ -197,13 +197,13 @@ describe('Tox', function() {
       });
     });
 
-    describe('#getFriendPublicKeyHex(), #getFriendPublicKeyHexSync()', function() {
-      it('should get the public key as hex', function() {
+    describe("#getFriendPublicKeyHex(), #getFriendPublicKeyHexSync()", function() {
+      it("should get the public key as hex", function() {
         var key = tox.getFriendPublicKeyHexSync(0);
         key.toLowerCase().should.equal(fakePublicKeys[2].toLowerCase());
       });
 
-      it('should get the public key as hex (async)', function(done) {
+      it("should get the public key as hex (async)", function(done) {
         tox.getFriendPublicKeyHex(1, function(err, key) {
           key.toLowerCase().should.equal(fakePublicKeys[3].toLowerCase());
           done(err);
@@ -211,13 +211,13 @@ describe('Tox', function() {
       });
     });
 
-    describe('#getFriendList(), #getFriendListSync()', function() {
-      it('should get all friends', function() {
+    describe("#getFriendList(), #getFriendListSync()", function() {
+      it("should get all friends", function() {
         var list = tox.getFriendListSync();
         list.length.should.equal(2);
       });
 
-      it('should get all friends (async)', function(done) {
+      it("should get all friends (async)", function(done) {
         tox.getFriendList(function(err, list) {
           list.length.should.equal(2);
           done(err);
@@ -225,26 +225,26 @@ describe('Tox', function() {
       });
     });
 
-    describe('#deleteFriend(), #deleteFriendSync()', function() {
-      it('should remove an existing friend', function() {
+    describe("#deleteFriend(), #deleteFriendSync()", function() {
+      it("should remove an existing friend", function() {
         tox.deleteFriendSync(0);
       });
 
-      it('should remove an existing friend (async)', function(done) {
+      it("should remove an existing friend (async)", function(done) {
         tox.deleteFriend(1, done);
       });
     });
   });
 
-  describe('#setName(), #setNameSync(), #getName(), #getNameSync()', function() {
-    it('should set and get the name', function() {
+  describe("#setName(), #setNameSync(), #getName(), #getNameSync()", function() {
+    it("should set and get the name", function() {
       var name = 'Hello world!';
       tox.setNameSync(name);
       tox.getNameSync().should.equal(name);
     });
 
-    it('should set and get the name (async)', function(done) {
-      var name = 'Some name';
+    it("should set and get the name (async)", function(done) {
+      var name = "Some name";
       tox.setName(name, function(err) {
         if(err) done(err);
         tox.getName(function(err, newName) {
@@ -255,15 +255,15 @@ describe('Tox', function() {
     });
   });
 
-  describe('#setStatusMessage(), #setStatusMessageSync(), #getStatusMessage(), #getStatusMessageSync()', function() {
-    it('should set and get the status message', function() {
+  describe("#setStatusMessage(), #setStatusMessageSync(), #getStatusMessage(), #getStatusMessageSync()", function() {
+    it("should set and get the status message", function() {
       var statusMessage = 'Hello world!';
       tox.setStatusMessageSync(statusMessage);
       tox.getStatusMessageSync().should.equal(statusMessage);
     });
 
-    it('should set and get the status message (async)', function(done) {
-      var statusMessage = 'Some status message';
+    it("should set and get the status message (async)", function(done) {
+      var statusMessage = "Some status message";
       tox.setStatusMessage(statusMessage, function(err) {
         if(err) done(err);
         tox.getStatusMessage(function(err, newStatusMessage) {
@@ -274,14 +274,14 @@ describe('Tox', function() {
     });
   });
 
-  describe('#setStatus(), #setStatusSync(), #getStatus(), #getStatusSync()', function() {
-    it('should set and get the status', function() {
+  describe("#setStatus(), #setStatusSync(), #getStatus(), #getStatusSync()", function() {
+    it("should set and get the status", function() {
       var status = 1;
       tox.setStatusSync(status);
       tox.getStatusSync().should.equal(status);
     });
 
-    it('should set and get the status (async)', function(done) {
+    it("should set and get the status (async)", function(done) {
       var status = 2;
       tox.setStatus(status, function(err) {
         if(err) done(err);
@@ -293,44 +293,44 @@ describe('Tox', function() {
     });
   });
 
-  describe('#addFriend(), #addFriendSync(), #addFriendNoRequest(), #addFriendNoRequestSync()', function() {
-    it('should add a friend from a hex string address', function() {
+  describe("#addFriend(), #addFriendSync(), #addFriendNoRequest(), #addFriendNoRequestSync()", function() {
+    it("should add a friend from a hex string address", function() {
       var addr = fakeAddresses[0],
-          friend = tox.addFriendSync(addr, 'Hi!');
-      should(friend).be.type('number');
+          friend = tox.addFriendSync(addr, "Hi!");
+      should(friend).be.type("number");
     });
 
-    it('should add a friend from a hex string address (async)', function(done) {
+    it("should add a friend from a hex string address (async)", function(done) {
       var addr = fakeAddresses[1];
-      tox.addFriend(addr, 'Hello', function(err, friend) {
-        should(friend).be.type('number');
+      tox.addFriend(addr, "Hello", function(err, friend) {
+        should(friend).be.type("number");
         done(err);
       });
     });
 
-    it('should add a friend from a hex string public key', function() {
+    it("should add a friend from a hex string public key", function() {
       var publicKey = fakePublicKeys[0],
           friend = tox.addFriendNoRequestSync(publicKey);
-      should(friend).be.type('number');
+      should(friend).be.type("number");
     });
 
-    it('should add a friend from a hex string public key (async)', function(done) {
+    it("should add a friend from a hex string public key (async)", function(done) {
       var publicKey = fakePublicKeys[1];
       tox.addFriendNoRequest(publicKey, function(err, friend) {
-        should(friend).be.type('number');
+        should(friend).be.type("number");
         done(err);
       });
     });
   });
 
-  describe('#getUdpPort(), #getUdpPortSync()', function() {
-    it('should return a Number with udp enabled by default', function() {
+  describe("#getUdpPort(), #getUdpPortSync()", function() {
+    it("should return a Number with udp enabled by default", function() {
       var port = tox.getUdpPortSync();
       port.should.be.a.Number;
       port.should.be.greaterThan(0);
     });
 
-    it('should return a Number with udp enabled by default (async)', function(done) {
+    it("should return a Number with udp enabled by default (async)", function(done) {
       tox.getUdpPort(function(err, port) {
         port.should.be.a.Number;
         port.should.be.greaterThan(0);
@@ -338,34 +338,34 @@ describe('Tox', function() {
       });
     });
 
-    it('should return the port specified', function() {
+    it("should return the port specified", function() {
       var port = toxCustomPort.getUdpPortSync();
       port.should.equal(customPort);
     });
 
-    it('should return the port specified (async)', function(done) {
+    it("should return the port specified (async)", function(done) {
       toxCustomPort.getUdpPort(function(err, port) {
         port.should.equal(customPort);
         done(err);
       });
     });
 
-    it('should throw a not-bound error if not listening on udp', function() {
+    it("should throw a not-bound error if not listening on udp", function() {
       (function() { toxNoUdp.getUdpPortSync(); }).should.throw();
     });
 
-    it('should return a not-bound error if not listening on udp (async)', function(done) {
+    it("should return a not-bound error if not listening on udp (async)", function(done) {
       toxNoUdp.getUdpPort(function(err, port) {
         should.exist(err);
         done();
       });
     });
 
-    it('should throw an error if no handle', function() {
+    it("should throw an error if no handle", function() {
       (function() { toxDead.getUdpPortSync(); }).should.throw();
     });
 
-    it('should return an error if no handle (async)', function(done) {
+    it("should return an error if no handle (async)", function(done) {
       toxDead.getUdpPort(function(err, port) {
         should.exist(err);
         done();
@@ -373,12 +373,12 @@ describe('Tox', function() {
     });
   });
 
-  describe('#getTcpPort(), #getTcpPortSync()', function() {
-    it('should throw a not-bound error if not a tcp relay', function() {
+  describe("#getTcpPort(), #getTcpPortSync()", function() {
+    it("should throw a not-bound error if not a tcp relay", function() {
       (function() { tox.getTcpPortSync(); }).should.throw();
     });
 
-    it('should return a not-bound error if not a tcp relay (async)', function(done) {
+    it("should return a not-bound error if not a tcp relay (async)", function(done) {
       tox.getTcpPort(function(err, port) {
         should.exist(err);
         done();
@@ -386,30 +386,30 @@ describe('Tox', function() {
     });
   });
 
-  describe('#isUdp()', function() {
-    it('should return true with udp enabled by default', function() {
+  describe("#isUdp()", function() {
+    it("should return true with udp enabled by default", function() {
       tox.isUdp().should.be.true;
     });
 
-    it('should return false if not listening on an udp port', function() {
+    it("should return false if not listening on an udp port", function() {
       toxNoUdp.isUdp().should.be.false;
     });
   });
 
-  describe('#isTcp()', function() {
-    it('should return false if not a tcp relay', function() {
+  describe("#isTcp()", function() {
+    it("should return false if not a tcp relay", function() {
       tox.isTcp().should.be.false;
     });
   });
 
-  describe('#getSavedataSize(), #getSavedataSizeSync(), #getSavedata(), #getSavedataSync()', function() {
-    it('should save data to a Buffer of the specified size', function() {
+  describe("#getSavedataSize(), #getSavedataSizeSync(), #getSavedata(), #getSavedataSync()", function() {
+    it("should save data to a Buffer of the specified size", function() {
       var size = tox.getSavedataSizeSync();
       var data = tox.getSavedataSync();
       data.length.should.equal(size);
     });
 
-    it('should save data to a Buffer of the specified size (async)', function(done) {
+    it("should save data to a Buffer of the specified size (async)", function(done) {
       tox.getSavedataSize(function(err, size) {
         if(err) {
           done(err);
@@ -423,7 +423,7 @@ describe('Tox', function() {
       });
     });
 
-    it('should load the savedata correctly', function() {
+    it("should load the savedata correctly", function() {
       var toxToSave = new Tox(),
           address = toxToSave.getAddressHexSync(),
           data = toxToSave.getSavedataSync();
@@ -431,23 +431,23 @@ describe('Tox', function() {
     });
   });
 
-  describe('#getOptions()', function() {
-    it('should handle proxies', function() {
-      var prox1 = new Tox({ proxy: { type: 'http', address: '12.34.56.92', port: 9411 } }),
+  describe("#getOptions()", function() {
+    it("should handle proxies", function() {
+      var prox1 = new Tox({ proxy: { type: "http", address: "12.34.56.92", port: 9411 } }),
           opts1 = prox1.getOptions();
       opts1.proxy_type.should.equal(consts.TOX_PROXY_TYPE_HTTP);
-      opts1.proxy_address.should.equal('12.34.56.92');
+      opts1.proxy_address.should.equal("12.34.56.92");
       opts1.proxy_port.should.equal(9411);
       prox1.free();
     });
   });
 
-  describe('crypto support', function() {
-    it('should be provided by default', function() {
+  describe("crypto support", function() {
+    it("should be provided by default", function() {
       tox.hasCrypto().should.be.true;
     });
 
-    it('should not break when the \'crypto\' option is passed to Tox constructor', function() {
+    it('should not break when the \'crypto\" option is passed to Tox constructor", function() {
       var toxWithCrypto1 = new Tox({ crypto: true }),
           toxWithCrypto2 = new Tox({ crypto: new ToxEncryptSave() }),
           toxWithoutCrypto1 = new Tox({ crypto: false });
@@ -456,12 +456,12 @@ describe('Tox', function() {
       toxWithoutCrypto1.hasCrypto().should.be.false;
     });
 
-    it('should automatically try to decrypt provided encrypted data, given a pass', function() {
+    it("should automatically try to decrypt provided encrypted data, given a pass", function() {
       this.timeout(5000);
       var toxToSave = new Tox(),
           address = toxToSave.getAddressHexSync(),
           data = toxToSave.getSavedataSync(),
-          passphrase = 'helloWorld',
+          passphrase = "helloWorld",
           edata = toxToSave.crypto().encryptSync(data, passphrase),
           toxEncrypted = [
             new Tox({ data: edata, pass: passphrase }),
@@ -472,30 +472,30 @@ describe('Tox', function() {
       });
     });
 
-    it('should throw if wrong passphrase is given', function() {
+    it("should throw if wrong passphrase is given", function() {
       var toxToSave = new Tox(),
           data = toxToSave.getSavedataSync(),
-          edata = toxToSave.crypto().encryptSync(data, 'myPassphrase');
+          edata = toxToSave.crypto().encryptSync(data, "myPassphrase");
       // Should throw TOX_ERR_DECRYPTION_FAILED
-      (function() { new Tox({ data: edata, pass: 'notThePass' }); }).should.throw();
+      (function() { new Tox({ data: edata, pass: "notThePass" }); }).should.throw();
     });
 
-    it('should not try to decrypt if no passphrase is given', function() {
+    it("should not try to decrypt if no passphrase is given", function() {
       var toxToSave = new Tox(),
           data = toxToSave.getSavedataSync(),
-          edata = toxToSave.crypto().encryptSync(data, 'myPassphrase');
+          edata = toxToSave.crypto().encryptSync(data, "myPassphrase");
       // Should throw TOX_ERR_NEW_LOAD_ENCRYPTED
       (function() { new Tox({ data: edata }); }).should.throw();
     });
   });
 
-  describe('version functions', function() {
-    it('should return numbers', function() {
+  describe("version functions", function() {
+    it("should return numbers", function() {
       var version = [ tox.versionMajorSync(), tox.versionMinorSync(), tox.versionPatchSync() ];
       version.forEach(function(num) { num.should.be.a.Number; });
     });
 
-    it('should return numbers (async)', function(done) {
+    it("should return numbers (async)", function(done) {
       async.parallel([
         tox.versionMajor.bind(tox),
         tox.versionMinor.bind(tox),
@@ -508,25 +508,25 @@ describe('Tox', function() {
   });
 
   // @todo: Address check
-  describe('nospam', function() {
-    it('should be a number', function() {
+  describe("nospam", function() {
+    it("should be a number", function() {
       tox.getNospamSync().should.be.a.Number;
     });
 
-    it('should be a number (async)', function(done) {
+    it("should be a number (async)", function(done) {
       tox.getNospam(function(err, nospam) {
         nospam.should.be.a.Number;
         done(err);
       });
     });
 
-    it('should set a number', function() {
+    it("should set a number", function() {
       var nospam = 0x1234;
       tox.setNospamSync(nospam);
       tox.getNospamSync().should.equal(nospam);
     });
 
-    it('should set a number (async)', function(done) {
+    it("should set a number (async)", function(done) {
       var nospam = 0x9876;
       async.series([
         Tox.prototype.setNospam.bind(tox, nospam),
@@ -538,13 +538,13 @@ describe('Tox', function() {
     });
   });
 
-  describe('ToxOptions', function() {
-    it('should allocate and free', function() {
+  describe("ToxOptions", function() {
+    it("should allocate and free", function() {
       var opts = tox.newOptionsSync();
       tox.freeOptionsSync(opts);
     });
 
-    it('should allocate and free (async)', function(done) {
+    it("should allocate and free (async)", function(done) {
       tox.newOptions(function(err, opts) {
         if(!err) {
           tox.freeOptions(opts, function(err) {
@@ -555,49 +555,49 @@ describe('Tox', function() {
     });
   });
 
-  describe('self key functions', function() {
-    it('should get the public key', function() {
+  describe("self key functions", function() {
+    it("should get the public key", function() {
       var key = tox.getPublicKeySync();
       key.length.should.equal(consts.TOX_PUBLIC_KEY_SIZE);
     });
 
-    it('should get the public key (async)', function(done) {
+    it("should get the public key (async)", function(done) {
       tox.getPublicKey(function(err, key) {
         key.length.should.equal(consts.TOX_PUBLIC_KEY_SIZE);
         done(err);
       });
     });
 
-    it('should get the public key as hex', function() {
+    it("should get the public key as hex", function() {
       var keyHex = tox.getPublicKeyHexSync();
       keyHex.length.should.equal(consts.TOX_PUBLIC_KEY_SIZE * 2);
     });
 
-    it('should get the public key as hex (async)', function(done) {
+    it("should get the public key as hex (async)", function(done) {
       tox.getPublicKeyHex(function(err, keyHex) {
         keyHex.length.should.equal(consts.TOX_PUBLIC_KEY_SIZE * 2);
         done(err);
       });
     });
 
-    it('should get the secret key', function() {
+    it("should get the secret key", function() {
       var key = tox.getSecretKeySync();
       key.length.should.equal(consts.TOX_SECRET_KEY_SIZE);
     });
 
-    it('should get the secret key (async)', function(done) {
+    it("should get the secret key (async)", function(done) {
       tox.getSecretKey(function(err, key) {
         key.length.should.equal(consts.TOX_SECRET_KEY_SIZE);
         done(err);
       });
     });
 
-    it('should get the secret key as hex', function() {
+    it("should get the secret key as hex", function() {
       var keyHex = tox.getSecretKeyHexSync();
       keyHex.length.should.equal(consts.TOX_SECRET_KEY_SIZE * 2);
     });
 
-    it('should get the secret key as hex (async)', function(done) {
+    it("should get the secret key as hex (async)", function(done) {
       tox.getSecretKeyHex(function(err, keyHex) {
         keyHex.length.should.equal(consts.TOX_SECRET_KEY_SIZE * 2);
         done(err);
@@ -605,18 +605,18 @@ describe('Tox', function() {
     });
   });
 
-  describe('saving and loading', function() {
+  describe("saving and loading", function() {
     var toxToSave = new Tox(),
         address = toxToSave.getAddressHexSync().toUpperCase();
 
-    it('should save and be loaded', function() {
+    it("should save and be loaded", function() {
       var data = toxToSave.getSavedataSync(),
           toxToLoad = new Tox({ data: data });
       toxToLoad.getAddressHexSync().toUpperCase().should.equal(address);
       toxToLoad.free();
     });
 
-    it('should save and be loaded (async)', function(done) {
+    it("should save and be loaded (async)", function(done) {
       toxToSave.getSavedata(function(err, data) {
         var toxToLoad = new Tox({ data: data });
         toxToLoad.getAddressHexSync().toUpperCase().should.equal(address);
@@ -625,7 +625,7 @@ describe('Tox', function() {
       });
     });
 
-    it('should save and be loaded from file', function() {
+    it("should save and be loaded from file", function() {
       var temp = mktempToxSync();
       toxToSave.saveToFileSync(temp);
       var toxToLoad = new Tox({ data: temp });
@@ -634,7 +634,7 @@ describe('Tox', function() {
       fs.unlinkSync(temp); // Remove file
     });
 
-    it('should save and be loaded from file (async)', function(done) {
+    it("should save and be loaded from file (async)", function(done) {
       var temp = mktempToxSync();
       toxToSave.saveToFile(temp, function(err) {
         if(!err) {
@@ -655,13 +655,13 @@ describe('Tox', function() {
     });
   });
 
-  describe('hashing', function() {
-    it('should hash some data', function() {
+  describe("hashing", function() {
+    it("should hash some data", function() {
       var hash = tox.hashSync(Buffer.from([0, 1, 2, 3]));
       hash.length.should.equal(consts.TOX_HASH_LENGTH);
     });
 
-    it('should hash some data (async)', function(done) {
+    it("should hash some data (async)", function(done) {
       tox.hash(Buffer.from([0, 1, 2, 3]), function(err, hash) {
         if(!err) {
           hash.length.should.equal(consts.TOX_HASH_LENGTH);
@@ -670,13 +670,13 @@ describe('Tox', function() {
       });
     });
 
-    it('should hash some string', function() {
-      var hash = tox.hashSync('aaa');
+    it("should hash some string", function() {
+      var hash = tox.hashSync("aaa");
       hash.length.should.equal(consts.TOX_HASH_LENGTH);
     });
 
-    it('should hash some string (async)', function(done) {
-      tox.hash('aaa', function(err, hash) {
+    it("should hash some string (async)", function(done) {
+      tox.hash("aaa", function(err, hash) {
         if(!err) {
           hash.length.should.equal(consts.TOX_HASH_LENGTH);
           done();
@@ -685,29 +685,29 @@ describe('Tox', function() {
     });
   });
 
-  describe('file control name to value', function() {
-    it('should convert from control name to control value correctly', function() {
+  describe("file control name to value", function() {
+    it("should convert from control name to control value correctly", function() {
       var RESUME = consts.TOX_FILE_CONTROL_RESUME,
           PAUSE = consts.TOX_FILE_CONTROL_PAUSE,
           CANCEL = consts.TOX_FILE_CONTROL_CANCEL;
 
-      tox._fixFileControl('resume').should.equal(RESUME);
-      tox._fixFileControl('Resume').should.equal(RESUME);
-      tox._fixFileControl('RESUME').should.equal(RESUME);
+      tox._fixFileControl("resume").should.equal(RESUME);
+      tox._fixFileControl("Resume").should.equal(RESUME);
+      tox._fixFileControl("RESUME").should.equal(RESUME);
       tox._fixFileControl(RESUME).should.equal(RESUME);
-      tox._fixFileControl('pause').should.equal(PAUSE);
-      tox._fixFileControl('Pause').should.equal(PAUSE);
-      tox._fixFileControl('PAUSE').should.equal(PAUSE);
+      tox._fixFileControl("pause").should.equal(PAUSE);
+      tox._fixFileControl("Pause").should.equal(PAUSE);
+      tox._fixFileControl("PAUSE").should.equal(PAUSE);
       tox._fixFileControl(PAUSE).should.equal(PAUSE);
-      tox._fixFileControl('cancel').should.equal(CANCEL);
-      tox._fixFileControl('Cancel').should.equal(CANCEL);
-      tox._fixFileControl('CANCEL').should.equal(CANCEL);
+      tox._fixFileControl("cancel").should.equal(CANCEL);
+      tox._fixFileControl("Cancel").should.equal(CANCEL);
+      tox._fixFileControl("CANCEL").should.equal(CANCEL);
       tox._fixFileControl(CANCEL).should.equal(CANCEL);
     });
   });
 
-  describe('event emitter', function() {
-    it('should be gettable from a Tox instance', function() {
+  describe("event emitter", function() {
+    it("should be gettable from a Tox instance", function() {
       should.exist(tox.getEmitter());
     });
   });

--- a/test/tox.js
+++ b/test/tox.js
@@ -447,7 +447,7 @@ describe("Tox", function() {
       tox.hasCrypto().should.be.true;
     });
 
-    it('should not break when the \'crypto\" option is passed to Tox constructor", function() {
+    it("should not break when the \"crypto\" option is passed to Tox constructor", function() {
       var toxWithCrypto1 = new Tox({ crypto: true }),
           toxWithCrypto2 = new Tox({ crypto: new ToxEncryptSave() }),
           toxWithoutCrypto1 = new Tox({ crypto: false });

--- a/test/toxencryptsave.js
+++ b/test/toxencryptsave.js
@@ -33,7 +33,7 @@ function loadModule(mod) {
 var ToxEncryptSave = loadModule("toxencryptsave");
 var consts = loadModule("consts");
 
-require("buffer")
+require("buffer");
 
 // Helper mktemp functions
 var mktempToxSync = mktemp.createFileSync.bind(undefined, "XXXXX.tox");

--- a/test/toxencryptsave.js
+++ b/test/toxencryptsave.js
@@ -39,7 +39,7 @@ require("buffer")
 var mktempToxSync = mktemp.createFileSync.bind(undefined, 'XXXXX.tox');
 
 var toxPassKeyToObject = function(passKey) {
-  return { key: new Buffer(passKey.key), salt: new Buffer(passKey.salt) };
+  return { key: Buffer.from(passKey.key), salt: Buffer.from(passKey.salt) };
 };
 
 describe('ToxEncryptSave', function() {
@@ -47,13 +47,13 @@ describe('ToxEncryptSave', function() {
 
   describe('encryption and decryption', function() {
     it('should detect encrypted data', function() {
-      var data = new Buffer('hello world'),
+      var data = Buffer.from('hello world'),
           edata = crypto.encryptSync(data, 'somePassphrase');
       crypto.isDataEncryptedSync(edata).should.be.true;
     });
 
     it('should detect encrypted data (async)', function(done) {
-      var data = new Buffer('hello async world');
+      var data = Buffer.from('hello async world');
       crypto.encrypt(data, 'someAsyncPassphrase', function(err, edata) {
         if(!err) {
           crypto.isDataEncrypted(edata, function(err, isEnc) {
@@ -67,7 +67,7 @@ describe('ToxEncryptSave', function() {
     });
 
     it('should be able to decrypt encrypted data', function() {
-      var data = new Buffer('some encrypted data'),
+      var data = Buffer.from('some encrypted data'),
           passphrase = 'somePassphrase',
           edata = crypto.encryptSync(data, passphrase);
 
@@ -81,7 +81,7 @@ describe('ToxEncryptSave', function() {
     });
 
     it('should be able to decrypt encrypted data (async)', function(done) {
-      var data = new Buffer('some encrypted data'),
+      var data = Buffer.from('some encrypted data'),
           passphrase = 'somePassphrase';
       crypto.encrypt(data, passphrase, function(err, edata) {
         if(!err) {
@@ -99,7 +99,7 @@ describe('ToxEncryptSave', function() {
 
     it('should be able to decrypt encrypted data from pass key', function() {
       var passKey = crypto.deriveKeyFromPassSync('passphrase'),
-          data = new Buffer('encrypt me with a pass key struct'),
+          data = Buffer.from('encrypt me with a pass key struct'),
           edata = crypto.encryptPassKeySync(data, passKey);
 
       (edata.equals(data)).should.be.false;
@@ -110,7 +110,7 @@ describe('ToxEncryptSave', function() {
     });
 
     it('should be able to decrypt encrypted data from pass key (async)', function(done) {
-      var data = new Buffer('encrypt me with a pass key struct async');
+      var data = Buffer.from('encrypt me with a pass key struct async');
       crypto.deriveKeyFromPass('somePass', function(err, passKey) {
         if(!err) {
           crypto.encryptPassKey(data, passKey, function(err, edata) {
@@ -130,7 +130,7 @@ describe('ToxEncryptSave', function() {
 
     it('should get the salt from encrypted data', function() {
       var pass = 'somePassword',
-          data = new Buffer('some data'),
+          data = Buffer.from('some data'),
           edata = crypto.encryptSync(data, pass),
           salt = crypto.getSaltSync(edata);
       salt.should.be.a.Buffer;
@@ -139,7 +139,7 @@ describe('ToxEncryptSave', function() {
 
     it('should get the salt from encrypted data (async)', function(done) {
       var pass = 'somePassphrase',
-          data = new Buffer('encrypt me');
+          data = Buffer.from('encrypt me');
       crypto.encrypt(data, pass, function(err, edata) {
         if(!err) {
           crypto.getSalt(edata, function(err, salt) {
@@ -156,7 +156,7 @@ describe('ToxEncryptSave', function() {
 
   describe('encryption and decryption (file helpers)', function() {
     it('should encrypt and decrypt to/from files', function() {
-      var data = new Buffer('encrypt me to a file'),
+      var data = Buffer.from('encrypt me to a file'),
           pass = 'somePassword',
           temp = mktempToxSync();
       crypto.encryptFileSync(temp, data, pass);
@@ -166,7 +166,7 @@ describe('ToxEncryptSave', function() {
     });
 
     it('should encrypt and decrypt to/from files (async)', function(done) {
-      var data = new Buffer('encrypt me to a file async'),
+      var data = Buffer.from('encrypt me to a file async'),
           pass = 'somePassphrase',
           temp = mktempToxSync();
       crypto.encryptFile(temp, data, pass, function(err) {

--- a/test/toxencryptsave.js
+++ b/test/toxencryptsave.js
@@ -17,7 +17,6 @@
  */
 
 var assert = require('assert');
-var buffertools = require('buffertools');
 var fs = require('fs');
 var mktemp = require('mktemp');
 var path = require('path');
@@ -34,7 +33,7 @@ function loadModule(mod) {
 var ToxEncryptSave = loadModule('toxencryptsave');
 var consts = loadModule('consts');
 
-buffertools.extend();
+require("buffer")
 
 // Helper mktemp functions
 var mktempToxSync = mktemp.createFileSync.bind(undefined, 'XXXXX.tox');

--- a/test/toxencryptsave.js
+++ b/test/toxencryptsave.js
@@ -16,45 +16,45 @@
  *
  */
 
-var assert = require('assert');
-var fs = require('fs');
-var mktemp = require('mktemp');
-var path = require('path');
-var should = require('should');
+var assert = require("assert");
+var fs = require("fs");
+var mktemp = require("mktemp");
+var path = require("path");
+var should = require("should");
 
 function loadModule(mod) {
   try {
-    return require(path.join('js-toxcore-c', 'js-toxcore-c', 'js-toxcore-c', 'lib', mod));
+    return require(path.join("js-toxcore-c", "js-toxcore-c", "js-toxcore-c", "lib", mod));
   } catch (e) {
-    return require(path.join(__dirname, '..', 'lib', mod));
+    return require(path.join(__dirname, "..", "lib", mod));
   }
 }
 
-var ToxEncryptSave = loadModule('toxencryptsave');
-var consts = loadModule('consts');
+var ToxEncryptSave = loadModule("toxencryptsave");
+var consts = loadModule("consts");
 
 require("buffer")
 
 // Helper mktemp functions
-var mktempToxSync = mktemp.createFileSync.bind(undefined, 'XXXXX.tox');
+var mktempToxSync = mktemp.createFileSync.bind(undefined, "XXXXX.tox");
 
 var toxPassKeyToObject = function(passKey) {
   return { key: Buffer.from(passKey.key), salt: Buffer.from(passKey.salt) };
 };
 
-describe('ToxEncryptSave', function() {
+describe("ToxEncryptSave", function() {
   var crypto = new ToxEncryptSave();
 
-  describe('encryption and decryption', function() {
-    it('should detect encrypted data', function() {
-      var data = Buffer.from('hello world'),
-          edata = crypto.encryptSync(data, 'somePassphrase');
+  describe("encryption and decryption", function() {
+    it("should detect encrypted data", function() {
+      var data = Buffer.from("hello world"),
+          edata = crypto.encryptSync(data, "somePassphrase");
       crypto.isDataEncryptedSync(edata).should.be.true;
     });
 
-    it('should detect encrypted data (async)', function(done) {
-      var data = Buffer.from('hello async world');
-      crypto.encrypt(data, 'someAsyncPassphrase', function(err, edata) {
+    it("should detect encrypted data (async)", function(done) {
+      var data = Buffer.from("hello async world");
+      crypto.encrypt(data, "someAsyncPassphrase", function(err, edata) {
         if(!err) {
           crypto.isDataEncrypted(edata, function(err, isEnc) {
             if(!err) {
@@ -66,9 +66,9 @@ describe('ToxEncryptSave', function() {
       });
     });
 
-    it('should be able to decrypt encrypted data', function() {
-      var data = Buffer.from('some encrypted data'),
-          passphrase = 'somePassphrase',
+    it("should be able to decrypt encrypted data", function() {
+      var data = Buffer.from("some encrypted data"),
+          passphrase = "somePassphrase",
           edata = crypto.encryptSync(data, passphrase);
 
       // Encrypted data should differ from original
@@ -80,9 +80,9 @@ describe('ToxEncryptSave', function() {
       (ddata.equals(data)).should.be.true;
     });
 
-    it('should be able to decrypt encrypted data (async)', function(done) {
-      var data = Buffer.from('some encrypted data'),
-          passphrase = 'somePassphrase';
+    it("should be able to decrypt encrypted data (async)", function(done) {
+      var data = Buffer.from("some encrypted data"),
+          passphrase = "somePassphrase";
       crypto.encrypt(data, passphrase, function(err, edata) {
         if(!err) {
           // Encrypted data should differ from original
@@ -97,9 +97,9 @@ describe('ToxEncryptSave', function() {
       });
     });
 
-    it('should be able to decrypt encrypted data from pass key', function() {
-      var passKey = crypto.deriveKeyFromPassSync('passphrase'),
-          data = Buffer.from('encrypt me with a pass key struct'),
+    it("should be able to decrypt encrypted data from pass key", function() {
+      var passKey = crypto.deriveKeyFromPassSync("passphrase"),
+          data = Buffer.from("encrypt me with a pass key struct"),
           edata = crypto.encryptPassKeySync(data, passKey);
 
       (edata.equals(data)).should.be.false;
@@ -109,9 +109,9 @@ describe('ToxEncryptSave', function() {
       (ddata.equals(data)).should.be.true;
     });
 
-    it('should be able to decrypt encrypted data from pass key (async)', function(done) {
-      var data = Buffer.from('encrypt me with a pass key struct async');
-      crypto.deriveKeyFromPass('somePass', function(err, passKey) {
+    it("should be able to decrypt encrypted data from pass key (async)", function(done) {
+      var data = Buffer.from("encrypt me with a pass key struct async");
+      crypto.deriveKeyFromPass("somePass", function(err, passKey) {
         if(!err) {
           crypto.encryptPassKey(data, passKey, function(err, edata) {
             if(!err) {
@@ -128,18 +128,18 @@ describe('ToxEncryptSave', function() {
       });
     });
 
-    it('should get the salt from encrypted data', function() {
-      var pass = 'somePassword',
-          data = Buffer.from('some data'),
+    it("should get the salt from encrypted data", function() {
+      var pass = "somePassword",
+          data = Buffer.from("some data"),
           edata = crypto.encryptSync(data, pass),
           salt = crypto.getSaltSync(edata);
       salt.should.be.a.Buffer;
       salt.length.should.equal(consts.TOX_PASS_SALT_LENGTH);
     });
 
-    it('should get the salt from encrypted data (async)', function(done) {
-      var pass = 'somePassphrase',
-          data = Buffer.from('encrypt me');
+    it("should get the salt from encrypted data (async)", function(done) {
+      var pass = "somePassphrase",
+          data = Buffer.from("encrypt me");
       crypto.encrypt(data, pass, function(err, edata) {
         if(!err) {
           crypto.getSalt(edata, function(err, salt) {
@@ -154,10 +154,10 @@ describe('ToxEncryptSave', function() {
     });
   });
 
-  describe('encryption and decryption (file helpers)', function() {
-    it('should encrypt and decrypt to/from files', function() {
-      var data = Buffer.from('encrypt me to a file'),
-          pass = 'somePassword',
+  describe("encryption and decryption (file helpers)", function() {
+    it("should encrypt and decrypt to/from files", function() {
+      var data = Buffer.from("encrypt me to a file"),
+          pass = "somePassword",
           temp = mktempToxSync();
       crypto.encryptFileSync(temp, data, pass);
       var ddata = crypto.decryptFileSync(temp, pass);
@@ -165,9 +165,9 @@ describe('ToxEncryptSave', function() {
       fs.unlinkSync(temp);
     });
 
-    it('should encrypt and decrypt to/from files (async)', function(done) {
-      var data = Buffer.from('encrypt me to a file async'),
-          pass = 'somePassphrase',
+    it("should encrypt and decrypt to/from files (async)", function(done) {
+      var data = Buffer.from("encrypt me to a file async"),
+          pass = "somePassphrase",
           temp = mktempToxSync();
       crypto.encryptFile(temp, data, pass, function(err) {
         if(!err) {
@@ -189,17 +189,17 @@ describe('ToxEncryptSave', function() {
     });
   });
 
-  describe('key derivation', function() {
-    it('should derive a key with a random salt', function() {
-      var obj = toxPassKeyToObject(crypto.deriveKeyFromPassSync('somePassword'));
+  describe("key derivation", function() {
+    it("should derive a key with a random salt", function() {
+      var obj = toxPassKeyToObject(crypto.deriveKeyFromPassSync("somePassword"));
       obj.key.should.be.a.Buffer;
       obj.key.length.should.equal(consts.TOX_PASS_KEY_LENGTH);
       obj.salt.should.be.a.Buffer;
       obj.salt.length.should.equal(consts.TOX_PASS_SALT_LENGTH);
     });
 
-    it('should derive a key with a random salt (async)', function(done) {
-      crypto.deriveKeyFromPass('somePassphrase', function(err, obj) {
+    it("should derive a key with a random salt (async)", function(done) {
+      crypto.deriveKeyFromPass("somePassphrase", function(err, obj) {
         if(!err) {
           obj = toxPassKeyToObject(obj);
           obj.key.should.be.a.Buffer;
@@ -211,16 +211,16 @@ describe('ToxEncryptSave', function() {
       });
     });
 
-    it('should derive a key with a given salt', function() {
-      var pass = 'somePassphrase',
+    it("should derive a key with a given salt", function() {
+      var pass = "somePassphrase",
           obj = toxPassKeyToObject(crypto.deriveKeyFromPassSync(pass)),
           otherObj = toxPassKeyToObject(crypto.deriveKeyWithSaltSync(pass, obj.salt));
       (obj.salt.equals(otherObj.salt)).should.be.true;
       (obj.key.equals(otherObj.key)).should.be.true;
     });
 
-    it('should derive a key with a given salt (async)', function(done) {
-      var pass = 'asyncPassword';
+    it("should derive a key with a given salt (async)", function(done) {
+      var pass = "asyncPassword";
       crypto.deriveKeyFromPass(pass, function(err, obj) {
         if(!err) {
           obj = toxPassKeyToObject(obj);

--- a/test/util.js
+++ b/test/util.js
@@ -17,7 +17,6 @@
  */
 
 var assert = require('assert');
-var buffertools = require('buffertools');
 var should = require('should');
 var path = require('path');
 
@@ -33,7 +32,7 @@ var util = loadModule('util');
 
 var size_t = util.size_t;
 
-buffertools.extend(); // Extend Buffer.prototype
+require("buffer");
 
 describe('util', function() {
   describe('#size_t()', function() {


### PR DESCRIPTION
This migrates from `node-ffi` to `node-ffi-napi`, as the former seems unmaintained and broken on recent node versions. The work for that is done by @Pigpog .

This PR includes the following `node-ffi-napi` PR to, well, fix it so that it is not crashing on c callbacks: https://github.com/node-ffi-napi/node-ffi-napi/pull/56

Fixes #17

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/js-toxcore-c/18)
<!-- Reviewable:end -->
