### PR TITLE
fix failing to convert key to hex

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -256,7 +256,7 @@ FriendRequestEvent.prototype.publicKey = function() {
  * @return {String} Public key as a hex String
  */
 FriendRequestEvent.prototype.publicKeyHex = function() {
-  return this._publicKey.toHex().toString();
+  return this._publicKey.toString("hex");
 };
 
 /**


### PR DESCRIPTION
Probably an accidental leftover from switching to proper buffers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/js-toxcore-c/19)
<!-- Reviewable:end -->
