### PR TITLE
Stop trying to build for ancient node.js versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,14 @@
 ---
 language: node_js
+os: linux
 
 cache:
   directories:
     - $HOME/cache
 
-matrix:
+jobs:
   include:
     - node_js: "node"
-    - node_js: "0.10"
-      if: type IN (push, api, cron)
-    - node_js: "0.12"
-      if: type IN (push, api, cron)
-    - node_js: "1"
-      if: type IN (push, api, cron)
-    - node_js: "2"
-      if: type IN (push, api, cron)
-    # Fails to compile module "nan":
-    # error: 'class v8::Object' has no member named 'DefineOwnProperty'
-#   - node_js: "3"
-#     if: type IN (push, api, cron)
     - node_js: "4"
       if: type IN (push, api, cron)
     - node_js: "5"


### PR DESCRIPTION
Our dependencies no longer support these versions, so let's stop trying
to, ourselves.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/js-toxcore-c/21)
<!-- Reviewable:end -->
