### PR TITLE
Remove support for nodejs 4-7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,6 @@ jobs:
       if: type IN (push, api, cron)
     - node_js: "8"
       if: type IN (push, api, cron)
-    - node_js: "7"
-      if: type IN (push, api, cron)
-    - node_js: "6"
-      if: type IN (push, api, cron)
-    - node_js: "5"
-      if: type IN (push, api, cron)
-    - node_js: "4"
-      if: type IN (push, api, cron)
 
 addons:
   apt:


### PR DESCRIPTION
These are ancient and no longer supported by our dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/js-toxcore-c/32)
<!-- Reviewable:end -->
