### PR TITLE
Run PR travis builds with the newest and oldest supported node.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ jobs:
     - node_js: "9"
       if: type IN (push, api, cron)
     - node_js: "8"
-      if: type IN (push, api, cron)
 
 addons:
   apt:


### PR DESCRIPTION
Cron builds continue to run with everything in between, but this way we
catch early when we do something that makes us no longer support the
oldest version we currently support (8).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/js-toxcore-c/33)
<!-- Reviewable:end -->
