### PR TITLE
Remove unused "else" case and throw errors in its case.

### DIFF
--- a/lib/tox.js
+++ b/lib/tox.js
@@ -3021,11 +3021,10 @@ Tox.prototype._initFriendLosslessPacketCb = function() {
       //} else {
       //  data = undefined;
       //}
-      if(ref.address(data) !== 0) {
-        data = Buffer.from(ref.reinterpret(data, length));
-      } else {
-        data = undefined;
+      if (ref.address(data) === 0) {
+        throw new Error("NULL data packet");
       }
+      data = Buffer.from(ref.reinterpret(data, length));
       _this._emit("friendLosslessPacket", new toxEvents.FriendPacketEvent(friend, data, true));
     }
   });
@@ -3042,11 +3041,10 @@ Tox.prototype._initFriendLossyPacketCb = function() {
     cb: FriendLossyPacketCallback,
     name: "FriendLossyPacketCallback",
     wrapper: function(handle, friend, data, length, userdata) {
-      if(ref.address(data) !== 0) {
-        data = Buffer.from(ref.reinterpret(data, length));
-      } else {
-        data = undefined;
+      if (ref.address(data) === 0) {
+        throw new Error("NULL data packet");
       }
+      data = Buffer.from(ref.reinterpret(data, length));
       _this._emit("friendLossyPacket", new toxEvents.FriendPacketEvent(friend, data, false));
     }
   });


### PR DESCRIPTION
We can't receive NULL from the packet callbacks. If that happens,
something is badly broken, so we throw an exception.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/js-toxcore-c/35)
<!-- Reviewable:end -->
