### PR TITLE
chore: Skip all branch builds.

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -5,7 +5,6 @@ repository:
   name: js-toxcore-c
   description: Node bindings for toxcore
   topics: toxcore, javascript
-  has_issues: true
 
 branches:
   - name: "master"

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,7 @@ script:
   - npm run test
   - npm run report-coverage
   - if [ "$CHECK_FORMAT" = true ]; then npm run format && git diff --exit-code; fi
+
+# Only build pull requests and releases, don't build master on pushes,
+# except through api or cron.
+if: type IN (pull_request, api, cron) OR tag IS present


### PR DESCRIPTION
Dependabot is putting a lot of load on travis because it creates
branches in the upstream repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/js-toxcore-c/43)
<!-- Reviewable:end -->
