### PR TITLE
chore: Drop support for node.js < 10.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,6 @@ jobs:
     - node_js: "11"
       if: type IN (push, api, cron)
     - node_js: "10"
-      if: type IN (push, api, cron)
-    - node_js: "9"
-      if: type IN (push, api, cron)
-    - node_js: "8"
 
 addons:
   apt:


### PR DESCRIPTION
ffi-napi has a security issue that's fixed in 3.0.0, which dropped
support for node.js < 10. This means we also need to drop that support
in order to upgrade.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/js-toxcore-c/53)
<!-- Reviewable:end -->
