### PR TITLE
Restyle chore: Require CI to pass before merging PRs.

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -11,10 +11,6 @@ branches:
     protection:
       required_status_checks:
         contexts:
-          - Codacy/PR Quality Review
-          - DeepScan
-          - Travis CI - Pull Request
-          - code-review/reviewable
-          - codecov/patch
-          - codecov/project
-          - security/snyk (TokTok)
+          - "build"
+          - "DeepScan"
+          - "security/snyk (TokTok)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,19 +1,19 @@
+---
 on:
   push:
-    branches-ignore:
-    - 'master'
+    branches: [master]
   pull_request:
+    branches: [master]
   schedule:
   - cron: '0 4 * * *' # Run at 04:00 every day.
 
 jobs:
   build:
-
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
     strategy:
       matrix:
-        node-version: [8.x, 9.x, 10.x, 12.x, 13.x]
+        node-version: [10.x, 12.x, 13.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -21,7 +21,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: sudo apt-get install libopus-dev libvpx-dev
+    - run: sudo apt-get install libopus-dev libsodium-dev libvpx-dev
     - name: Set up environment variables
       run: |
         # GITHUB_ENV doesn't update the env vars in the current step, so export this one too.

--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -2,22 +2,6 @@
 
 set -eux
 
-# install libsodium, needed for crypto
-if ! [ -d libsodium ]; then
-  git clone --depth=1 --branch=1.0.3 https://github.com/jedisct1/libsodium.git
-fi
-cd libsodium
-git rev-parse HEAD > libsodium.sha
-if ! ([ -f "$CACHE_DIR/libsodium.sha" ] && diff "$CACHE_DIR/libsodium.sha" libsodium.sha); then
-  ./autogen.sh
-  ./configure --prefix="$CACHE_DIR/usr"
-  make -j`nproc`
-  make install
-  mv libsodium.sha "$CACHE_DIR/libsodium.sha"
-fi
-cd ..
-rm -rf libsodium
-
 # install toxcore
 if ! [ -d toxcore ]; then
   git clone --depth=1 --branch=master https://github.com/TokTok/toxcore.git toxcore
@@ -25,7 +9,7 @@ fi
 cd toxcore
 git rev-parse HEAD > toxcore.sha
 if ! ([ -f "$CACHE_DIR/toxcore.sha" ] && diff "$CACHE_DIR/toxcore.sha" toxcore.sha); then
-  cmake -B_build -H. -DCMAKE_INSTALL_PREFIX:PATH=$HOME/cache/usr
+  cmake -B_build -H. -DCMAKE_INSTALL_PREFIX:PATH="$HOME/cache/usr"
   make -C_build -j`nproc`
   make -C_build install
   mv toxcore.sha "$CACHE_DIR/toxcore.sha"

--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -7,7 +7,7 @@ if ! [ -d toxcore ]; then
   git clone --depth=1 --branch=master https://github.com/TokTok/toxcore.git toxcore
 fi
 cd toxcore
-git rev-parse HEAD > toxcore.sha
+git rev-parse HEAD >toxcore.sha
 if ! ([ -f "$CACHE_DIR/toxcore.sha" ] && diff "$CACHE_DIR/toxcore.sha" toxcore.sha); then
   cmake -B_build -H. -DCMAKE_INSTALL_PREFIX:PATH="$HOME/cache/usr"
   make -C_build -j"$(nproc)"

--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -10,7 +10,7 @@ cd toxcore
 git rev-parse HEAD > toxcore.sha
 if ! ([ -f "$CACHE_DIR/toxcore.sha" ] && diff "$CACHE_DIR/toxcore.sha" toxcore.sha); then
   cmake -B_build -H. -DCMAKE_INSTALL_PREFIX:PATH="$HOME/cache/usr"
-  make -C_build -j`nproc`
+  make -C_build -j"$(nproc)"
   make -C_build install
   mv toxcore.sha "$CACHE_DIR/toxcore.sha"
 fi


### PR DESCRIPTION

A duplicate of #111 with additional commits that automatically address
incorrect style, created by [Restyled][].

Since the original Pull Request was opened as a fork in a contributor's
repository, we are unable to create a Pull Request branching from it with only
the style fixes.

The following Restylers made fixes:

- shellharden
- shfmt


To incorporate these changes, you can either:

1. Merge this Pull Request *instead of* the original, or

1. Ask your contributor to locally incorporate these commits and push them to
   the original Pull Request

   <details>
       <summary>Expand for example instructions</summary>

       ```console
       git remote add upstream https://github.com/TokTok/js-toxcore-c.git
       git fetch upstream pull/<this PR number>/head
       git merge --ff-only FETCH_HEAD
       git push
       ```

   </details>


**NOTE**: As work continues on the original Pull Request, this process will
re-run and update (force-push) this Pull Request with updated style fixes as
necessary. If the style is fixed manually at any point (i.e. this process finds
no fixes to make), this Pull Request will be closed automatically.

Sorry if this was unexpected. To disable it, see our [documentation][].

[restyled]: https://restyled.io
[documentation]: https://github.com/restyled-io/restyled.io/wiki/Disabling-Restyled

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/js-toxcore-c/118)
<!-- Reviewable:end -->
