### PR TITLE
chore: Make it possible to run npm format on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "doc": "grunt jsdoc",
     "test": "nyc mocha",
     "report-coverage": "nyc report --reporter=text-lcov  > coverage.lcov && codecov",
-    "format": "prettier --write '**/*.js' '**/*.ts' '**/*.json'"
+    "format": "prettier --write \"**/*.js\" \"**/*.ts\" \"**/*.json\""
   },
   "dependencies": {
     "ffi-napi": "^4.0.3",


### PR DESCRIPTION
With single-quoted paths, it fails with "No files matching the pattern
found."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/js-toxcore-c/128)
<!-- Reviewable:end -->
