### PR TITLE
chore: Add nodejs 21.x to the CI targets.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 13.x, 20.x]
+        node-version: [12.x, 13.x, 20.x, 21.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This is the one used in Alpine 3.19.0.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/js-toxcore-c/188)
<!-- Reviewable:end -->
